### PR TITLE
Downgrade psutil>=5.7.3 to psutil>=5.7.2 requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     license='BSD-3',
     include_package_data=True,
     data_files=get_data_files(),
-    install_requires=['psutil>=5.7.3','PyGObject','pycairo'],
+    install_requires=['psutil>=5.7.2','PyGObject','pycairo'],
     packages=find_packages(),
     entry_points=dict(
         console_scripts=[


### PR DESCRIPTION
Can we downgrade `psutils` for compatibility with not to old Linux distros? For example Fedora still have 5.7.2 in [f33 branch](https://src.fedoraproject.org/rpms/python-psutil). This allows us packaging SysMonTask for official repos.