### PR TITLE
docs: Add Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ OR
 
 Install using pamac(gui for software add/remove), first enable the AUR(arch user repository) in preferences, then search sysmontask, install and enjoy.
 
+### #Fedora:
+
+Available in official [Fedora repos](https://src.fedoraproject.org/rpms/sysmontask).
+```
+$ sudo dnf install sysmontask
+```
+
 ---
 ### #Installing using PIP(PyPi) 
 To install using pip, run:


### PR DESCRIPTION
Packaged for Fedora and now [on QA](https://bodhi.fedoraproject.org/updates/FEDORA-2021-01715c88f2).

Also may i ask you to tag a new version in near future with canonical versioning scheme? Something like `v1.1.1-beta.3` or `v1.1.1-beta3`?