### PR TITLE
Update property names in English

### DIFF
--- a/glade_files/sysmontask.glade
+++ b/glade_files/sysmontask.glade
@@ -885,7 +885,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE</property>
                                             <property name="halign">start</property>
                                             <property name="margin-start">15</property>
                                             <property name="hexpand">True</property>
-                                            <property name="label" translatable="yes">% Utilisation</property>
+                                            <property name="label" translatable="yes">% Utilization</property>
                                           </object>
                                           <packing>
                                             <property name="left-attach">0</property>
@@ -1202,7 +1202,7 @@ NA</property>
                                                     <property name="margin-start">13</property>
                                                     <property name="margin-top">10</property>
                                                     <property name="hexpand">True</property>
-                                                    <property name="label" translatable="yes">Utilisation</property>
+                                                    <property name="label" translatable="yes">Utilization</property>
                                                   </object>
                                                   <packing>
                                                     <property name="left-attach">0</property>
@@ -1487,7 +1487,7 @@ NA</property>
                                                 <property name="halign">start</property>
                                                 <property name="margin-start">10</property>
                                                 <property name="hexpand">True</property>
-                                                <property name="label" translatable="yes">Virtualisation:</property>
+                                                <property name="label" translatable="yes">Virtualization:</property>
                                               </object>
                                               <packing>
                                                 <property name="left-attach">0</property>


### PR DESCRIPTION
Changed letter 's' for 'z'  wich is used in English for words "Utilization" and "Virtualization"