### PR TITLE
Stop using popen to calculate the number of threads - addresses #21

### DIFF
--- a/sysmontask/cpu.py
+++ b/sysmontask/cpu.py
@@ -181,13 +181,17 @@ def cpuUpdate(self):
     self.cpuUtilLabelValue.set_text(cpuUtilString)
 
     # Setting number of processes and threads")
-    self.cpuProcessesLabelValue.set_text(str(len(ps.pids())))
-    try:
-        p=popen("ps axms|wc -l")
-        self.cpuThreadsLabelValue.set_text(sub('[\s]','',p.read()))
-        p.close()
-    except:
-        print("Failed to get Threads")
+    # pids + 3 less than the original way of calculating the number of threads, because we no longer fork to create a `ps` and a `wc` process and `ps axms` has a header line
+    # Additionally, `ps axms` shows a single-threaded process on one line and its thread on another line. You should have been using `ps axH`
+    pid_iter = ps.process_iter()
+    pids, threads = (0, 0)
+    # I'm not good at python, there might be a smarter way to get the number of pids than incrementing in the while loop. This is probably good enough though
+    for proc in pid_iter:
+        threads += proc.num_threads()
+        pids += 1
+        print("pid: %d threads: %d" % (pids, threads))
+    self.cpuProcessesLabelValue.set_text(str(pids))
+    self.cpuThreadsLabelValue.set_text(str(threads))
 
     try:
         #cpu package temp

--- a/sysmontask/cpu.py
+++ b/sysmontask/cpu.py
@@ -189,7 +189,6 @@ def cpuUpdate(self):
     for proc in pid_iter:
         threads += proc.num_threads()
         pids += 1
-        print("pid: %d threads: %d" % (pids, threads))
     self.cpuProcessesLabelValue.set_text(str(pids))
     self.cpuThreadsLabelValue.set_text(str(threads))
 


### PR DESCRIPTION
Obviously doesn't fix it, but it removes one of the calls at least, and one of the more important ones as this was happening every time it updated.

Also fixes a bug in the initial program, where it would display `Threads: NUM_THREADS+NUM_PROCESSES` rather than just the number of threads because it ran `ps axms` rather than `ps axH`.

Let me know if you want me to remove the (pretty useless) comments, or if there is a better way to get the number of loops of the iterator.