### PR TITLE
Replace both times that popen("cat | grep") is used

### DIFF
--- a/sysmontask/cpu.py
+++ b/sysmontask/cpu.py
@@ -48,13 +48,15 @@ def cpuInit(self):
     self.cpuFanSpeedLabelValue=self.builder.get_object('cpufanspeedlabelvalue')
     self.cpuMxSpeedLabelValue=self.builder.get_object('cpumxspeedlabelvalue')
 
+    # Get the name of the CPU
     try:
-        ## for the first time only to get the name of the cpu
-        p=popen('cat /proc/cpuinfo |grep -m1 "model name"')
-        self.cpuname=p.read().split(':')[1].split('\n')[0]
+        with open("/proc/cpuinfo") as cpuinfo:
+            for line in cpuinfo:
+                if line.startswith('model name'):
+                    self.cpuname = line.split(':')[1].strip()
+                    break
         self.cpuInfoLabel.set_text(self.cpuname)
         self.cpuInfoLabel.set_valign(g.Align.CENTER)
-        p.close()
     except:
         print("Failed to get model information")
 

--- a/sysmontask/mem.py
+++ b/sysmontask/mem.py
@@ -69,10 +69,11 @@ def memorytabinit(self):
 
     # Getting the Corrupted memory info
     try:
-        p=popen('cat /proc/meminfo | grep -E -i "corrupted"')
-        tempcourrupted=p.read().split(':')[1]
-        p.close()
-        self.memCourruptedLabelValue.set_text(re.sub('\s','',tempcourrupted))
+        with open("/proc/meminfo") as meminfo:
+            for line in meminfo:
+                if line.startswith('HardwareCorrupted'):
+                    self.memCourruptedLabelValue.set_text(line.split(':')[1].strip())
+                    break
     except:
         print("Failed to get Corrupted Memory")
 


### PR DESCRIPTION
Since we can just open the file in python, these were easy to change.