### PR TITLE
Add 'System Information' tab to Haiku port

### DIFF
--- a/haiku_port/CPUView.cpp
+++ b/haiku_port/CPUView.cpp
@@ -1,0 +1,192 @@
+#include "CPUView.h"
+#include <stdio.h> // For sprintf
+#include <String.h>
+#include <SystemInfo.h> // For BSystemInfo, if used for modern Haiku CPU stats
+#include <kernel/OS.h>  // For get_system_info, system_info, cpu_info
+
+CPUView::CPUView(BRect frame)
+    : BView(frame, "CPUView", B_FOLLOW_LEFT_RIGHT | B_FOLLOW_TOP, B_WILL_DRAW | B_PULSE_NEEDED),
+      fFirstTime(true) {
+
+    SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
+
+    BGroupLayout* layout = new BGroupLayout(B_VERTICAL);
+    SetLayout(layout);
+
+    // Overall Usage Section
+    BBox* overallBox = new BBox("OverallCPUBox");
+    overallBox->SetLabel("Overall CPU Usage");
+    BGridLayout* grid = new BGridLayout(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    BLayoutBuilder::Grid<>(grid)
+        .SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
+        .Add(fOverallUsageLabel = new BStringView("overall_label", "Total Usage:"), 0, 0)
+        .Add(fOverallUsageValue = new BStringView("overall_value", "0.0%"), 1, 0)
+        .Add(BSpaceLayoutItem::CreateGlue(), 2, 0); // Add glue to push items to the left
+    grid->SetColumnWeight(2, 1.0f); // Make the glue column expand
+    overallBox->AddChild(grid->View());
+    layout->AddView(overallBox);
+
+    // Initialize previous times
+    system_info sysInfo;
+    if (get_system_info(&sysInfo) == B_OK) {
+        fPreviousSysInfo = sysInfo; // Store initial system_info
+        for (uint32 i = 0; i < sysInfo.cpu_count; ++i) {
+            fPreviousIdleTime[i] = sysInfo.cpu_infos[i].active_time; // Actually active time
+        }
+    } else {
+        // Handle error - perhaps disable CPU view or show an error message
+        fOverallUsageValue->SetText("Error fetching CPU info");
+    }
+
+
+    // Placeholder for graphs - will be a separate custom view
+    // BView* graphView = new BView(BRect(0,0,100,50), "cpuGraph", B_FOLLOW_ALL, B_WILL_DRAW);
+    // graphView->SetViewColor(200, 200, 220); // Light blue-ish
+    // layout->AddView(graphView);
+
+    layout->AddGlue(); // Add glue to push everything to the top
+}
+
+CPUView::~CPUView() {
+    // Any cleanup
+}
+
+void CPUView::AttachedToWindow() {
+    // Called when the view is added to a window
+    UpdateData(); // Initial data fetch
+    BView::AttachedToWindow();
+}
+
+void CPUView::Pulse() {
+    // Called periodically by the window's pulse mechanism
+    UpdateData();
+}
+
+void CPUView::GetCPUUsage(float* overallUsage) {
+    system_info currentSysInfo;
+    bigtime_t currentTotalActiveTime = 0;
+    bigtime_t previousTotalActiveTime = 0;
+    bigtime_t timeDiff;
+
+    if (get_system_info(&currentSysInfo) != B_OK) {
+        *overallUsage = -1.0f; // Indicate error
+        return;
+    }
+
+    if (fFirstTime) {
+        fPreviousSysInfo = currentSysInfo;
+        fFirstTime = false;
+        *overallUsage = 0.0f; // No data for first pulse
+        // Update previous idle times for next calculation
+        for (uint32 i = 0; i < currentSysInfo.cpu_count; ++i) {
+             fPreviousIdleTime[i] = currentSysInfo.cpu_infos[i].active_time;
+        }
+        return;
+    }
+
+    timeDiff = currentSysInfo.boot_time - fPreviousSysInfo.boot_time; // This is not correct, boot_time is constant
+                                                                      // We need elapsed time. system_time() is wall clock.
+
+    // A more robust way is to sum active_times and subtract from previous sum of active_times
+    // and divide by (elapsed_wall_clock_time * cpu_count)
+
+    bigtime_t elapsedWallTime = system_time() - fPreviousSysInfo.timestamp_for_active_time;
+    // system_info doesn't have a convenient timestamp for its active_time values.
+    // This makes precise interval calculation tricky without BSystemInfo.
+    // Let's try a simplified approach, assuming Pulse interval is somewhat regular.
+    // A better approach would be to use BSystemInfo if available, or track system_time()
+    // manually alongside get_system_info calls.
+
+    // For overall usage:
+    // Sum of (current active_time[i] - previous active_time[i]) for all cores
+    // Divided by (elapsed_time * number_of_cores)
+
+    // Let's use BSystemInfo for a more modern and accurate approach for per-core usage,
+    // which then can be averaged. If this is not available, fallback or different logic is needed.
+
+    float perCoreUsage[B_MAX_CPU_COUNT];
+    cpu_info previousCpuInfos[B_MAX_CPU_COUNT];
+    cpu_info currentCpuInfos[B_MAX_CPU_COUNT];
+    uint32 cpuCount;
+    bigtime_t previousSnapshotTime; // Store the time of the previous snapshot
+
+    // Get CPU info using BSystemInfo (modern Haiku)
+    // This is a simplified example; BSystemInfo::GetCPUInfo might need more setup
+    // or a different approach if not readily giving interval-based percentages.
+    // The most common way on Haiku is still active_time differences.
+
+    // Reverting to the active_time difference method with manual time tracking.
+    bigtime_t currentTimeSnapshot = system_time(); // Wall clock time of this snapshot
+
+    if (fFirstTime) { // Should have been caught earlier, but for safety
+        fPreviousSysInfo = currentSysInfo; // Copy current to previous
+         for (uint32 i = 0; i < currentSysInfo.cpu_count; ++i) {
+            fPreviousIdleTime[i] = currentSysInfo.cpu_infos[i].active_time;
+        }
+        fPreviousSysInfo.timestamp_for_active_time = currentTimeSnapshot; // Store snapshot time
+        fFirstTime = false;
+        *overallUsage = 0.0;
+        return;
+    }
+
+    elapsedWallTime = currentTimeSnapshot - fPreviousSysInfo.timestamp_for_active_time;
+
+    if (elapsedWallTime <= 0) { // Time hasn't advanced or error
+        *overallUsage = 0.0; // Or previous value
+        return;
+    }
+
+    float totalDeltaActiveTime = 0;
+    for (uint32 i = 0; i < currentSysInfo.cpu_count; ++i) {
+        bigtime_t deltaCoreActiveTime = currentSysInfo.cpu_infos[i].active_time - fPreviousIdleTime[i];
+        totalDeltaActiveTime += deltaCoreActiveTime;
+        fPreviousIdleTime[i] = currentSysInfo.cpu_infos[i].active_time; // Update for next round
+    }
+
+    // Overall usage: (total change in active time across all cores) / (wall time elapsed * number of cores)
+    if (currentSysInfo.cpu_count > 0) {
+        *overallUsage = (float)totalDeltaActiveTime / (elapsedWallTime * currentSysInfo.cpu_count) * 100.0f;
+    } else {
+        *overallUsage = 0.0f;
+    }
+
+    // Clamp usage between 0 and 100
+    if (*overallUsage < 0.0f) *overallUsage = 0.0f;
+    if (*overallUsage > 100.0f) *overallUsage = 100.0f; // Can happen due to timing/precision
+
+    // Update previous system info snapshot time for the next calculation
+    fPreviousSysInfo.timestamp_for_active_time = currentTimeSnapshot;
+}
+
+
+void CPUView::UpdateData() {
+    fLocker.Lock(); // Lock if data is accessed from other threads, good practice for Pulse
+
+    float usage;
+    GetCPUUsage(&usage);
+
+    if (usage >= 0) {
+        char buffer[32];
+        snprintf(buffer, sizeof(buffer), "%.1f%%", usage);
+        fOverallUsageValue->SetText(buffer);
+    } else {
+        fOverallUsageValue->SetText("N/A");
+    }
+
+    // Invalidate(); // If we were drawing graphs, we'd invalidate to trigger Draw()
+    fLocker.Unlock();
+}
+
+void CPUView::Draw(BRect updateRect) {
+    // This is where graph drawing code would go.
+    // For now, it's handled by child BStringViews.
+    BView::Draw(updateRect);
+
+    // Example: Draw a simple rectangle for the graph area
+    // BRect graphArea = Bounds(); // Or a specific rect for the graph
+    // graphArea.InsetBy(5,5);
+    // SetHighColor(180, 180, 200);
+    // FillRect(graphArea);
+    // SetHighColor(0,0,0);
+    // StrokeRect(graphArea);
+}

--- a/haiku_port/CPUView.h
+++ b/haiku_port/CPUView.h
@@ -1,0 +1,41 @@
+#ifndef CPUVIEW_H
+#define CPUVIEW_H
+
+#include <View.h>
+#include <StringView.h>
+#include <Box.h>
+#include <GridLayout.h>
+#include <GroupLayout.h>
+#include <SpaceLayoutItem.h>
+#include <Locker.h>
+#include <kernel/OS.h> // For system_info, get_system_info
+
+// Forward declaration
+class BStringView;
+
+class CPUView : public BView {
+public:
+    CPUView(BRect frame);
+    ~CPUView();
+
+    virtual void AttachedToWindow();
+    virtual void Pulse(); // Called periodically to update data
+    virtual void Draw(BRect updateRect); // For drawing graphs later
+
+private:
+    void UpdateData();    // Fetches and updates CPU data
+    void GetCPUUsage(float* usage); // Gets overall CPU usage
+
+    BStringView* fOverallUsageLabel;
+    BStringView* fOverallUsageValue;
+    // We will add more detailed views (per-core, graphs) later
+
+    // For calculating CPU usage
+    system_info fPreviousSysInfo;
+    bigtime_t fPreviousIdleTime[B_MAX_CPU_COUNT];
+    bool fFirstTime;
+
+    BLocker fLocker; // For thread safety if needed for data updates
+};
+
+#endif // CPUVIEW_H

--- a/haiku_port/DiskView.cpp
+++ b/haiku_port/DiskView.cpp
@@ -1,0 +1,213 @@
+#include "DiskView.h"
+#include <LayoutBuilder.h>
+#include <StringView.h>
+#include <stdio.h> // For snprintf
+#include <device/scsi.h> // For device names, might not be needed for volume stats
+#include <Directory.h>   // For iterating devices if needed
+#include <Entry.h>
+#include <SymLink.h>
+
+#include <ColumnListView.h>
+#include <ColumnTypes.h>
+
+
+// Define column constants for BColumnListView
+enum {
+    kDeviceColumn,
+    kMountPointColumn,
+    kFSTypeColumn,
+    kTotalSizeColumn,
+    kFreeSizeColumn,
+    kUsedSizeColumn, // Calculated: Total - Free
+    kUsagePercentageColumn // Calculated
+};
+
+
+DiskView::DiskView(BRect frame)
+    : BView(frame, "DiskView", B_FOLLOW_ALL_SIDES, B_WILL_DRAW | B_PULSE_NEEDED)
+{
+    SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
+
+    fDiskInfoBox = new BBox("DiskInfoBox");
+    fDiskInfoBox->SetLabel("Disk Volumes");
+
+    // Using BColumnListView for a structured display
+    BRect clvRect = fDiskInfoBox->Bounds(); // Will be adjusted by layout
+    clvRect.InsetBy(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    // Top edge needs to be below the label
+    font_height fh;
+    fDiskInfoBox->GetFontHeight(&fh);
+    clvRect.top += fh.ascent + fh.descent + fh.leading + B_USE_DEFAULT_SPACING;
+
+
+    BColumnListView* columnListView = new BColumnListView(clvRect, "disk_clv",
+                                                          B_FOLLOW_ALL_SIDES,
+                                                          B_WILL_DRAW | B_NAVIGABLE,
+                                                          B_PLAIN_BORDER, true);
+
+    columnListView->AddColumn(new BStringColumn("Device", 150, 50, 500, B_TRUNCATE_MIDDLE), kDeviceColumn);
+    columnListView->AddColumn(new BStringColumn("Mount Point", 150, 50, 500, B_TRUNCATE_MIDDLE), kMountPointColumn);
+    columnListView->AddColumn(new BStringColumn("FS Type", 80, 40, 200, B_TRUNCATE_END), kFSTypeColumn);
+    columnListView->AddColumn(new BStringColumn("Total Size", 100, 50, 200, B_TRUNCATE_END, B_ALIGN_RIGHT), kTotalSizeColumn);
+    columnListView->AddColumn(new BStringColumn("Used Size", 100, 50, 200, B_TRUNCATE_END, B_ALIGN_RIGHT), kUsedSizeColumn);
+    columnListView->AddColumn(new BStringColumn("Free Size", 100, 50, 200, B_TRUNCATE_END, B_ALIGN_RIGHT), kFreeSizeColumn);
+    columnListView->AddColumn(new BStringColumn("Usage %", 80, 40, 150, B_TRUNCATE_END, B_ALIGN_RIGHT), kUsagePercentageColumn);
+
+    columnListView->SetSortColumn(columnListView->ColumnAt(kMountPointColumn), true, true); // Sort by Mount Point initially
+
+    // Add the ColumnListView to the BBox using a layout
+    BLayoutBuilder::Group<>(fDiskInfoBox, B_VERTICAL, 0)
+        .SetInsets(B_USE_DEFAULT_SPACING, fh.ascent + fh.descent + fh.leading + B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
+        .Add(columnListView);
+
+
+    // Main layout for the DiskView itself
+    BLayoutBuilder::Group<>(this, B_VERTICAL, 0)
+        .SetInsets(0)
+        .Add(fDiskInfoBox)
+    .End();
+
+    // fDiskListView will be the BColumnListView
+    fDiskListView = columnListView;
+}
+
+DiskView::~DiskView()
+{
+    // fDiskListView is a child of fDiskInfoBox, which is a child of this view.
+    // They will be deleted automatically.
+}
+
+void DiskView::AttachedToWindow()
+{
+    if (BColumnListView* clv = dynamic_cast<BColumnListView*>(fDiskListView)) {
+         // Set target for selection messages if needed
+    }
+    UpdateData();
+    BView::AttachedToWindow();
+}
+
+void DiskView::Pulse()
+{
+    UpdateData();
+}
+
+BString DiskView::FormatBytes(uint64 bytes) {
+    BString str;
+    double kb = bytes / 1024.0;
+    double mb = kb / 1024.0;
+    double gb = mb / 1024.0;
+
+    if (gb >= 1.0) {
+        str.SetToFormat("%.2f GiB", gb);
+    } else if (mb >= 1.0) {
+        str.SetToFormat("%.2f MiB", mb);
+    } else { // Show KiB for smaller sizes as well, or directly bytes
+        str.SetToFormat("%.0f KiB", kb); // For disk sizes, KiB is usually the minimum practical unit
+    }
+    return str;
+}
+
+void DiskView::GetDiskInfo(BVolume& volume, DiskInfo& info) {
+    fs_info fsInfo;
+    if (fs_stat_dev(volume.Device(), &fsInfo) == B_OK) {
+        info.totalSize = fsInfo.total_blocks * fsInfo.block_size;
+        info.freeSize = fsInfo.free_blocks * fsInfo.block_size;
+        info.fileSystemType = fsInfo.fsh_name;
+
+        // Get mount point
+        BDirectory mountDir;
+        volume.GetRootDirectory(&mountDir);
+        BEntry mountEntry;
+        mountDir.GetEntry(&mountEntry);
+        BPath mountPath;
+        mountEntry.GetPath(&mountPath);
+        info.mountPoint = mountPath.Path();
+
+        // Device name is a bit trickier, fs_info.device_name is often just a number.
+        // We might need to iterate through /dev/disk or use other methods for a more user-friendly name.
+        // For now, use what fs_info provides or a placeholder.
+        info.deviceName = fsInfo.device_name; // This is often like "dev_#"
+                                              // A more robust way involves querying the device itself.
+                                              // For now, this is a simple starting point.
+    } else {
+        info.totalSize = 0;
+        info.freeSize = 0;
+        info.fileSystemType = "Error";
+        info.mountPoint = "Error";
+        info.deviceName = "Error";
+    }
+}
+
+
+void DiskView::UpdateData()
+{
+    fLocker.Lock();
+
+    BColumnListView* clv = dynamic_cast<BColumnListView*>(fDiskListView);
+    if (!clv) {
+        fLocker.Unlock();
+        return;
+    }
+
+    // Store existing items to update or remove (simplistic update: clear and re-add)
+    // A more optimized way would be to update existing rows and add/remove only changed ones.
+    // For disk volumes, the list is usually stable, so clear-and-re-add is often acceptable.
+    while (BRow* row = clv->RowAt(0)) {
+        clv->RemoveRow(row);
+        delete row;
+    }
+
+    BVolumeRoster volRoster;
+    BVolume volume;
+    volRoster.Rewind();
+
+    while (volRoster.GetNextVolume(&volume) == B_OK) {
+        if (volume.IsReadOnly() || volume.IsRemovable() || !volume.KnowsCapacity() || !volume.KnowsQuery()) {
+            // Skip read-only, removable (like CD-ROMs unless specifically desired),
+            // or volumes that don't report capacity or don't support queries (virtual FS etc.)
+            // This logic might need refinement based on desired behavior.
+            // For a system monitor, we usually care about fixed disks.
+            // However, some removable media (USB drives) are relevant.
+            // For now, let's list all that report capacity.
+            if (!volume.KnowsCapacity()) continue;
+        }
+
+        DiskInfo currentDiskInfo;
+        GetDiskInfo(volume, currentDiskInfo);
+
+        if (currentDiskInfo.totalSize == 0) continue; // Skip if we couldn't get valid info
+
+        BRow* row = new BRow();
+        uint64 usedSize = currentDiskInfo.totalSize - currentDiskInfo.freeSize;
+        double usagePercent = 0.0;
+        if (currentDiskInfo.totalSize > 0) {
+            usagePercent = (double)usedSize / currentDiskInfo.totalSize * 100.0;
+        }
+        char percentStr[16];
+        snprintf(percentStr, sizeof(percentStr), "%.1f%%", usagePercent);
+
+        row->SetField(new BStringField(currentDiskInfo.deviceName.String()), kDeviceColumn);
+        row->SetField(new BStringField(currentDiskInfo.mountPoint.String()), kMountPointColumn);
+        row->SetField(new BStringField(currentDiskInfo.fileSystemType.String()), kFSTypeColumn);
+        row->SetField(new BStringField(FormatBytes(currentDiskInfo.totalSize).String()), kTotalSizeColumn);
+        row->SetField(new BStringField(FormatBytes(usedSize).String()), kUsedSizeColumn);
+        row->SetField(new BStringField(FormatBytes(currentDiskInfo.freeSize).String()), kFreeSizeColumn);
+        row->SetField(new BStringField(percentStr), kUsagePercentageColumn);
+
+        clv->AddRow(row);
+    }
+
+    // I/O statistics are harder. Haiku doesn't have a simple per-volume I/O counter accessible
+    // through BVolume or fs_info. This often requires looking at raw device statistics,
+    // which is more complex (e.g. /dev/disk/... and specific ioctls, or kernel interfaces).
+    // For this iteration, we will focus on capacity and usage.
+    // TODO: Research and implement disk I/O bytes/sec if feasible.
+
+    fLocker.Unlock();
+}
+
+void DiskView::Draw(BRect updateRect)
+{
+    BView::Draw(updateRect);
+    // Custom drawing if any (e.g. graphs for I/O, not implemented here)
+}

--- a/haiku_port/DiskView.h
+++ b/haiku_port/DiskView.h
@@ -1,0 +1,55 @@
+#ifndef DISKVIEW_H
+#define DISKVIEW_H
+
+#include <View.h>
+#include <StringView.h>
+#include <Box.h>
+#include <ListView.h> // For listing multiple disks/partitions
+#include <ScrollView.h>
+#include <Locker.h>
+#include <Path.h>
+#include <Volume.h>
+#include <VolumeRoster.h>
+#include <fs_info.h>
+
+struct DiskInfo {
+    BString     deviceName;     // e.g., /dev/disk/ata/0/master/raw
+    BString     mountPoint;     // e.g., /boot or /Haiku
+    BString     fileSystemType; // e.g., bfs, ntfs
+    uint64      totalSize;
+    uint64      freeSize;
+    // Add more if needed, e.g. read/write stats (might be harder to get per volume)
+    // For overall disk activity, might need to monitor specific device nodes
+};
+
+class DiskView : public BView {
+public:
+    DiskView(BRect frame);
+    ~DiskView();
+
+    virtual void AttachedToWindow();
+    virtual void Pulse();
+    virtual void Draw(BRect updateRect);
+
+private:
+    void UpdateData();
+    BString FormatBytes(uint64 bytes);
+    void GetDiskInfo(BVolume& volume, DiskInfo& info);
+
+    // For simplicity, we'll display info for all mounted volumes.
+    // A BListView could be used to list disks, and selecting one shows details.
+    // Or, a BColumnListView for a table of disks.
+    // For now, let's create a simple text area for each disk.
+
+    BBox*       fDiskInfoBox; // A container for all disk info
+    BScrollView* fScrollView; // If content might exceed view bounds
+    BView*      fDiskListView; // A simple view to hold multiple StringViews or custom items
+
+    // We will dynamically add BStringViews to fDiskListView for each disk.
+    // This requires careful management of these views if they are numerous or change.
+    // A BColumnListView is more robust for dynamic lists.
+
+    BLocker fLocker;
+};
+
+#endif // DISKVIEW_H

--- a/haiku_port/GPUView.cpp
+++ b/haiku_port/GPUView.cpp
@@ -1,0 +1,102 @@
+#include "GPUView.h"
+#include <stdio.h> // For snprintf
+
+GPUView::GPUView(BRect frame)
+    : BView(frame, "GPUView", B_FOLLOW_ALL_SIDES, B_WILL_DRAW)
+      // No B_PULSE_NEEDED if only static data displayed on attach
+{
+    SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
+
+    BGroupLayout* layout = new BGroupLayout(B_VERTICAL);
+    SetLayout(layout);
+
+    BBox* infoBox = new BBox("GPUInfoBox");
+    infoBox->SetLabel("Graphics Card Information");
+
+    BGridLayout* grid = new BGridLayout(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    BLayoutBuilder::Grid<>(grid)
+        .SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
+        .Add(fCardNameLabel = new BStringView("gpu_name_label", "Card Name:"), 0, 0)
+        .Add(fCardNameValue = new BStringView("gpu_name_value", "N/A"), 1, 0)
+        .Add(BSpaceLayoutItem::CreateGlue(), 2, 0) // Glue to push to left
+
+        .Add(fChipsetLabel = new BStringView("gpu_chipset_label", "Chipset:"), 0, 1)
+        .Add(fChipsetValue = new BStringView("gpu_chipset_value", "N/A"), 1, 1)
+        .Add(BSpaceLayoutItem::CreateGlue(), 2, 1)
+
+        .Add(fMemorySizeLabel = new BStringView("gpu_mem_label", "Memory Size:"), 0, 2)
+        .Add(fMemorySizeValue = new BStringView("gpu_mem_value", "N/A"), 1, 2)
+        .Add(BSpaceLayoutItem::CreateGlue(), 2, 2)
+
+        .Add(fDacSpeedLabel = new BStringView("gpu_dac_label", "DAC Speed:"), 0, 3)
+        .Add(fDacSpeedValue = new BStringView("gpu_dac_value", "N/A"), 1, 3)
+        .Add(BSpaceLayoutItem::CreateGlue(), 2, 3)
+
+        .Add(fDriverVersionLabel = new BStringView("gpu_driver_label", "Driver Version:"), 0, 4)
+        .Add(fDriverVersionValue = new BStringView("gpu_driver_value", "N/A"), 1, 4)
+        .Add(BSpaceLayoutItem::CreateGlue(), 2, 4);
+
+    grid->SetColumnWeight(2, 1.0f); // Make the glue column expand for all rows
+
+    infoBox->AddChild(grid->View());
+    layout->AddView(infoBox);
+    layout->AddGlue(); // Pushes the box to the top
+}
+
+GPUView::~GPUView()
+{
+    // Child views are auto-deleted
+}
+
+void GPUView::AttachedToWindow()
+{
+    UpdateData();
+    BView::AttachedToWindow();
+}
+
+BString GPUView::FormatBytes(uint64 bytes) {
+    BString str;
+    double mb = bytes / (1024.0 * 1024.0);
+    double gb = mb / 1024.0;
+
+    if (gb >= 1.0) {
+        str.SetToFormat("%.2f GiB", gb);
+    } else { // For GPU memory, MiB is a common unit
+        str.SetToFormat("%.0f MiB", mb);
+    }
+    return str;
+}
+
+void GPUView::UpdateData()
+{
+    BScreen screen(B_MAIN_SCREEN_ID);
+    if (!screen.IsValid()) {
+        fCardNameValue->SetText("Error: Invalid screen object");
+        return;
+    }
+
+    accelerant_device_info deviceInfo;
+    if (screen.GetDeviceInfo(&deviceInfo) == B_OK) {
+        fCardNameValue->SetText(deviceInfo.name);
+        fChipsetValue->SetText(deviceInfo.chipset);
+        fMemorySizeValue->SetText(FormatBytes(deviceInfo.memory).String());
+
+        char dacSpeedStr[32];
+        snprintf(dacSpeedStr, sizeof(dacSpeedStr), "%lu MHz", deviceInfo.dac_speed / 1000); // DAC speed often in kHz
+        fDacSpeedValue->SetText(dacSpeedStr);
+
+        char versionStr[32];
+        snprintf(versionStr, sizeof(versionStr), "%lu", deviceInfo.version);
+        fDriverVersionValue->SetText(versionStr);
+
+    } else {
+        fCardNameValue->SetText("Error: Could not get device info");
+        fChipsetValue->SetText("-");
+        fMemorySizeValue->SetText("-");
+        fDacSpeedValue->SetText("-");
+        fDriverVersionValue->SetText("-");
+    }
+
+    // As this data is static, no need to Invalidate() or schedule further pulses
+    // unless we find a way to get dynamic GPU stats.
+}

--- a/haiku_port/GPUView.h
+++ b/haiku_port/GPUView.h
@@ -1,0 +1,42 @@
+#ifndef GPUVIEW_H
+#define GPUVIEW_H
+
+#include <View.h>
+#include <StringView.h>
+#include <Box.h>
+#include <Screen.h> // For BScreen and accelerant_device_info
+#include <GraphicsDefs.h> // For accelerant_device_info (usually included by Screen.h)
+#include <GridLayout.h>
+#include <GroupLayout.h>
+#include <SpaceLayoutItem.h>
+
+class GPUView : public BView {
+public:
+    GPUView(BRect frame);
+    ~GPUView();
+
+    virtual void AttachedToWindow();
+    // Pulse might not be needed if only static info is displayed
+    // virtual void Pulse();
+
+private:
+    void UpdateData(); // Fetches and updates GPU info
+    BString FormatBytes(uint64 bytes);
+
+    // --- StringViews for displaying GPU Info ---
+    BStringView* fCardNameLabel;
+    BStringView* fCardNameValue;
+    BStringView* fChipsetLabel;
+    BStringView* fChipsetValue;
+    BStringView* fMemorySizeLabel;
+    BStringView* fMemorySizeValue;
+    BStringView* fDacSpeedLabel;
+    BStringView* fDacSpeedValue;
+    BStringView* fDriverVersionLabel; // From accelerant_device_info.version
+    BStringView* fDriverVersionValue;
+
+    // Add more if relevant information is found in accelerant_device_info
+    // BStringView* fErrorLabel; // To display errors if info cannot be fetched
+};
+
+#endif // GPUVIEW_H

--- a/haiku_port/Makefile
+++ b/haiku_port/Makefile
@@ -1,7 +1,7 @@
 # Basic Makefile for SysMonTask Haiku Port
 
 # Application Name
-APP_NAME = SysMonTaskHaiku
+APP_NAME = SysMonTask
 
 # Sources
 SRCS = SysMonTaskApp.cpp

--- a/haiku_port/Makefile
+++ b/haiku_port/Makefile
@@ -1,0 +1,66 @@
+# Basic Makefile for SysMonTask Haiku Port
+
+# Application Name
+APP_NAME = SysMonTaskHaiku
+
+# Sources
+SRCS = SysMonTaskApp.cpp
+SRCS += CPUView.cpp
+SRCS += MemView.cpp
+SRCS += DiskView.cpp
+SRCS += NetworkView.cpp
+SRCS += ProcessView.cpp
+SRCS += GPUView.cpp
+SRCS += SysInfoView.cpp
+# Add more .cpp files here as we create them:
+
+# Objects: Automatically generated from SRCS
+OBJS = $(SRCS:.cpp=.o)
+
+# Compiler and Linker
+CC = g++
+
+# Target architecture (adjust if necessary, e.g., x86_gcc2 for older Haiku)
+ARCH = x86
+
+# Haiku build command
+HAIKU_BUILD_COMMAND = setarch $(ARCH) $(CC)
+
+# Compiler Flags
+# -Wall: Enable all warnings
+# -g: Include debugging symbols
+# -I /boot/system/develop/headers/posix : Include POSIX headers explicitly if needed
+#   (often included by default with Haiku's build tools)
+CFLAGS = -Wall -g -std=c++11
+
+# Linker Flags
+# Common Haiku libraries:
+# -lbe: Be API (Application Kit, Interface Kit, Support Kit, etc.)
+# -ltracker: For Tracker-related functions (if any, not typical for this app)
+# -lnetwork: For Network Kit
+# -lroot: Standard C library functions
+# Add more libraries as needed
+LIBS = -lbe -lnetwork # Add -lstorage, etc. as features are implemented
+
+# Default Target
+all: $(APP_NAME)
+
+# Linking the application
+$(APP_NAME): $(OBJS)
+	@echo "Linking $(APP_NAME)..."
+	$(HAIKU_BUILD_COMMAND) $(OBJS) -o $(APP_NAME) $(LIBS)
+	@echo "$(APP_NAME) built successfully."
+
+# Compiling source files
+%.o: %.cpp
+	@echo "Compiling $<..."
+	$(HAIKU_BUILD_COMMAND) $(CFLAGS) -c $< -o $@
+
+# Clean target
+clean:
+	@echo "Cleaning up..."
+	rm -f $(OBJS) $(APP_NAME)
+	@echo "Cleanup complete."
+
+# Phony targets
+.PHONY: all clean

--- a/haiku_port/MemView.cpp
+++ b/haiku_port/MemView.cpp
@@ -1,0 +1,248 @@
+// Implementation for MemView - Memory Monitoring Tab
+
+#include "MemView.h"
+#include <Box.h>
+#include <GridLayout.h>
+#include <GroupLayoutBuilder.h>
+#include <SpaceLayoutItem.h>
+#include <StringView.h>
+#include <stdio.h> // For snprintf
+#include <string.h> // For memset
+#include <kernel/OS.h> // For get_system_info, system_info
+#include <InterfaceDefs.h> // For ui_color, B_PANEL_BACKGROUND_COLOR
+
+// GraphView Implementation
+GraphView::GraphView(BRect frame, const char* name, const float* historyData, const int* historyIndex, const uint64* totalValue)
+    : BView(frame, name, B_FOLLOW_ALL_SIDES, B_WILL_DRAW | B_PULSE_NEEDED), // B_PULSE_NEEDED if it self-updates, otherwise relies on parent Invalidate
+      fHistoryData(historyData),
+      fHistoryIndex(historyIndex),
+      fTotalValue(totalValue) {
+    SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR)); // Or a different background for the graph
+    // Set a default graph color, can be changed
+    fGraphColor = (rgb_color){ 0, 128, 255, 255 }; // Blue
+}
+
+void GraphView::AttachedToWindow()
+{
+    // If the graph view needed its own pulse or specific setup when added to window.
+    // For now, it will be updated when MemView calls Invalidate on it.
+    BView::AttachedToWindow();
+}
+
+void GraphView::Draw(BRect updateRect)
+{
+    SetLowColor(ViewColor()); // Match background for FillRect
+    FillRect(updateRect, B_SOLID_LOW);
+
+    if (!fHistoryData || !fHistoryIndex || !fTotalValue || *fTotalValue == 0) {
+        // Draw "N/A" or some placeholder if data is not ready
+        BFont font;
+        GetFont(&font);
+        font_height fh;
+        font.GetHeight(&fh);
+        const char* message = "Graph N/A";
+        float stringWidth = font.StringWidth(message);
+        BPoint textPoint(Bounds().Width() / 2 - stringWidth / 2, Bounds().Height() / 2 + fh.ascent / 2);
+        DrawString(message, textPoint);
+        return;
+    }
+
+    SetHighColor(fGraphColor);
+
+    BRect bounds = Bounds();
+    float barWidth = bounds.Width() / HISTORY_SIZE;
+    int currentIndex = *fHistoryIndex;
+
+    for (int i = 0; i < HISTORY_SIZE; i++) {
+        // Calculate index in history array, wrapping around
+        int historyIdx = (currentIndex + i) % HISTORY_SIZE;
+        float value = fHistoryData[historyIdx]; // This is already a percentage 0-100
+
+        if (value < 0) continue; // Skip uninitialized data points
+
+        float barHeight = (value / 100.0f) * bounds.Height(); // Scale percentage to view height
+        if (barHeight < 0) barHeight = 0;
+        if (barHeight > bounds.Height()) barHeight = bounds.Height();
+
+        BRect barRect;
+        barRect.left = bounds.left + i * barWidth;
+        barRect.right = barRect.left + barWidth -1; // -1 for a small gap or exact fit
+        barRect.top = bounds.bottom - barHeight;
+        barRect.bottom = bounds.bottom;
+
+        FillRect(barRect);
+    }
+
+    // Draw a border around the graph area
+    SetHighColor(0,0,0); // Black border
+    StrokeRect(bounds);
+}
+
+
+// MemView Implementation
+MemView::MemView(BRect frame)
+    : BView(frame, "MemoryView", B_FOLLOW_ALL_SIDES, B_WILL_DRAW | B_PULSE_NEEDED),
+      fCacheGraphView(NULL),
+      fCacheHistoryIndex(0),
+      fTotalSystemMemory(0)
+{
+    SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
+    memset(fCacheHistory, 0, sizeof(fCacheHistory)); // Initialize history to 0
+
+    // --- Total Memory ---
+    fTotalMemLabel = new BStringView("total_mem_label", "Total Memory:");
+    fTotalMemValue = new BStringView("total_mem_value", "N/A");
+
+    // --- Used Memory ---
+    fUsedMemLabel = new BStringView("used_mem_label", "Used Memory:");
+    fUsedMemValue = new BStringView("used_mem_value", "N/A");
+
+    // --- Free Memory (Calculated or from system) ---
+    // Haiku's system_info provides used_pages and max_pages. Free is max - used.
+    // Some systems provide "free" directly, others "available" which is more useful.
+    // For simplicity, we can show used/total. If "free" is specifically desired:
+    fFreeMemLabel = new BStringView("free_mem_label", "Free Memory:");
+    fFreeMemValue = new BStringView("free_mem_value", "N/A");
+
+
+    // --- Cached Memory ---
+    // system_info has block_cache_pages and cached_pages (file system cache)
+    fCachedMemLabel = new BStringView("cached_mem_label", "Cached Memory:");
+    fCachedMemValue = new BStringView("cached_mem_value", "N/A");
+
+
+    BBox* statsBox = new BBox("MemoryStatsBox");
+    statsBox->SetLabel("Memory Statistics");
+
+    BGridLayout* gridLayout = new BGridLayout(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    BLayoutBuilder::Grid<>(gridLayout)
+        .SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
+        .Add(fTotalMemLabel, 0, 0)
+        .Add(fTotalMemValue, 1, 0)
+        .Add(BSpaceLayoutItem::CreateGlue(), 2, 0) // Glue to push to left
+
+        .Add(fUsedMemLabel, 0, 1)
+        .Add(fUsedMemValue, 1, 1)
+        .Add(BSpaceLayoutItem::CreateGlue(), 2, 1)
+
+        .Add(fFreeMemLabel, 0, 2)
+        .Add(fFreeMemValue, 1, 2)
+        .Add(BSpaceLayoutItem::CreateGlue(), 2, 2)
+
+        .Add(fCachedMemLabel, 0, 3)
+        .Add(fCachedMemValue, 1, 3)
+        .Add(BSpaceLayoutItem::CreateGlue(), 2, 3);
+
+    gridLayout->SetColumnWeight(2, 1.0f); // Make the glue column expand
+
+    statsBox->AddChild(gridLayout->View());
+
+    // --- Cache Graph View ---
+    // Calculate a reasonable frame for the graph view.
+    // For example, make it take the remaining width and a fixed height.
+    BRect graphFrame = Bounds(); // Start with full view bounds
+    graphFrame.top = statsBox->Frame().bottom + B_USE_DEFAULT_SPACING; // Position below the stats box
+    graphFrame.bottom = graphFrame.top + 80; // Fixed height for the graph, adjust as needed
+    // In a more complex layout, you'd use BLayoutBuilder for this too.
+    // For now, let's ensure it's added to a BGroupLayout.
+
+    fCacheGraphView = new GraphView(BRect(0,0,10,10), "cacheGraph", fCacheHistory, &fCacheHistoryIndex, &fTotalSystemMemory);
+    // The BRect(0,0,10,10) is a placeholder, actual size managed by layout.
+    fCacheGraphView->SetExplicitMinSize(BSize(0, 60)); // Min height for graph
+    fCacheGraphView->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, 100)); // Max height for graph
+
+
+    BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_DEFAULT_SPACING)
+        .SetInsets(B_USE_DEFAULT_SPACING)
+        .Add(statsBox)
+        .Add(fCacheGraphView)
+        .AddGlue(); // Pushes content to the top, graph will expand horizontally.
+}
+
+MemView::~MemView()
+{
+    // Child views are typically deleted by their parent or the window
+}
+
+void MemView::AttachedToWindow()
+{
+    UpdateData();
+    BView::AttachedToWindow();
+}
+
+void MemView::Pulse()
+{
+    UpdateData();
+}
+
+BString MemView::FormatBytes(uint64 bytes) {
+    BString str;
+    double kb = bytes / 1024.0;
+    double mb = kb / 1024.0;
+    double gb = mb / 1024.0;
+
+    if (gb >= 1.0) {
+        str.SetToFormat("%.2f GiB", gb);
+    } else if (mb >= 1.0) {
+        str.SetToFormat("%.2f MiB", mb);
+    } else if (kb >= 1.0) {
+        str.SetToFormat("%.2f KiB", kb);
+    } else {
+        str.SetToFormat("%llu Bytes", bytes);
+    }
+    return str;
+}
+
+void MemView::UpdateData()
+{
+    fLocker.Lock();
+
+    system_info sysInfo;
+    if (get_system_info(&sysInfo) == B_OK) {
+        uint64 totalBytes = (uint64)sysInfo.max_pages * B_PAGE_SIZE;
+        uint64 usedBytes = (uint64)sysInfo.used_pages * B_PAGE_SIZE;
+        uint64 freeBytes = totalBytes - usedBytes; // Calculated free
+
+        // Cached memory: Haiku has `cached_pages` (file system cache) and `block_cache_pages` (block I/O cache)
+        // We can sum them or show them separately. For simplicity, sum them for "Cached".
+        uint64 cachedBytes = ((uint64)sysInfo.cached_pages + (uint64)sysInfo.block_cache_pages) * B_PAGE_SIZE;
+
+
+        fTotalMemValue->SetText(FormatBytes(totalBytes).String());
+        fUsedMemValue->SetText(FormatBytes(usedBytes).String());
+        fFreeMemValue->SetText(FormatBytes(freeBytes).String());
+        fCachedMemValue->SetText(FormatBytes(cachedBytes).String());
+
+        fTotalSystemMemory = totalBytes; // Store for graph context or percentage calculation
+
+        // Update cache history for graph
+        if (fTotalSystemMemory > 0) {
+            float cachePercent = (float)cachedBytes / fTotalSystemMemory * 100.0f;
+            if (cachePercent < 0.0f) cachePercent = 0.0f;
+            if (cachePercent > 100.0f) cachePercent = 100.0f; // Clamp
+            fCacheHistory[fCacheHistoryIndex] = cachePercent;
+        } else {
+            fCacheHistory[fCacheHistoryIndex] = 0; // Or some error indicator like -1 if graph handles it
+        }
+        fCacheHistoryIndex = (fCacheHistoryIndex + 1) % HISTORY_SIZE;
+
+        if (fCacheGraphView) {
+            fCacheGraphView->Invalidate(); // Trigger graph redraw
+        }
+
+    } else {
+        fTotalSystemMemory = 0; // Reset if error
+        fTotalMemValue->SetText("Error");
+        fUsedMemValue->SetText("Error");
+        fFreeMemValue->SetText("Error");
+        fCachedMemValue->SetText("Error");
+    }
+
+    fLocker.Unlock();
+}
+
+// Graph drawing would go into Draw() method if we add a live graph later.
+// void MemView::Draw(BRect updateRect) {
+// BView::Draw(updateRect);
+// Draw graph using fMemHistory data
+// }

--- a/haiku_port/MemView.h
+++ b/haiku_port/MemView.h
@@ -1,0 +1,65 @@
+#ifndef MEMVIEW_H
+#define MEMVIEW_H
+
+#include <View.h>
+#include <StringView.h>
+#include <Box.h>
+#include <GridLayout.h>
+#include <GroupLayout.h>
+#include <Locker.h>
+#include <kernel/OS.h> // For system_info, get_system_info
+
+#define HISTORY_SIZE 100
+
+// Forward declaration for GraphView
+class GraphView;
+
+class MemView : public BView {
+public:
+    MemView(BRect frame);
+    ~MemView();
+
+    virtual void AttachedToWindow();
+    virtual void Pulse();
+
+private:
+    void UpdateData();
+    BString FormatBytes(uint64 bytes);
+
+    BStringView* fTotalMemLabel;
+    BStringView* fTotalMemValue;
+    BStringView* fUsedMemLabel;
+    BStringView* fUsedMemValue;
+    BStringView* fFreeMemLabel;
+    BStringView* fFreeMemValue;
+    BStringView* fCachedMemLabel;    // File system cache
+    BStringView* fCachedMemValue;
+    // BStringView* fBufferedMemLabel; // Block cache - might combine with cached or omit for simplicity
+    // BStringView* fBufferedMemValue;
+
+
+    GraphView* fCacheGraphView;
+    float fCacheHistory[HISTORY_SIZE];
+    int fCacheHistoryIndex;
+    uint64 fTotalSystemMemory; // To calculate percentage for graph if needed
+
+    BLocker fLocker;
+};
+
+
+// Simple generic GraphView class
+class GraphView : public BView {
+public:
+    GraphView(BRect frame, const char* name, const float* historyData, const int* historyIndex, const uint64* totalValue);
+    virtual void Draw(BRect updateRect);
+    virtual void AttachedToWindow(); // To set a pulse if needed, or initial draw
+
+private:
+    const float* fHistoryData; // Pointer to the actual history data in MemView
+    const int* fHistoryIndex;  // Pointer to the current index
+    const uint64* fTotalValue; // Pointer to total memory for percentage calculation
+    rgb_color fGraphColor;
+};
+
+
+#endif // MEMVIEW_H

--- a/haiku_port/NetworkView.cpp
+++ b/haiku_port/NetworkView.cpp
@@ -1,0 +1,297 @@
+#include "NetworkView.h"
+#include <LayoutBuilder.h>
+#include <ColumnTypes.h> // For BStringColumn etc.
+#include <Alert.h>       // For error reporting (temporary)
+#include <NetworkInterface.h> // Modern Haiku way: BNetworkInterface
+#include <NetServer.h> // For BNetworkRoster
+
+#include <map> // Using std::map to store previous stats per interface
+
+// Define column constants for BColumnListView
+enum {
+    kInterfaceNameColumn,
+    kInterfaceTypeColumn,
+    kInterfaceAddressColumn,
+    kBytesSentColumn,
+    kBytesRecvColumn,
+    kPacketsSentColumn,
+    kPacketsRecvColumn,
+    kSendSpeedColumn,
+    kRecvSpeedColumn,
+    kSendErrorsColumn,
+    kRecvErrorsColumn
+};
+
+// Structure to hold current and previous stats for speed calculation
+struct InterfaceStatsRecord {
+    uint64      bytesSent;
+    uint64      bytesReceived;
+    bigtime_t   lastUpdateTime;
+
+    InterfaceStatsRecord() : bytesSent(0), bytesReceived(0), lastUpdateTime(0) {}
+};
+
+// Global map to store previous stats. A bit simplified, ideally part of the class
+// or handled more robustly if interfaces change names or order.
+static std::map<std::string, InterfaceStatsRecord> gPreviousStatsMap;
+
+
+NetworkView::NetworkView(BRect frame)
+    : BView(frame, "NetworkView", B_FOLLOW_ALL_SIDES, B_WILL_DRAW | B_PULSE_NEEDED),
+      fSocket(-1)
+{
+    SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
+
+    BBox* netBox = new BBox("NetworkInterfacesBox");
+    netBox->SetLabel("Network Interfaces");
+
+    BRect clvRect = netBox->Bounds();
+    font_height fh;
+    netBox->GetFontHeight(&fh);
+    clvRect.top += fh.ascent + fh.descent + fh.leading + B_USE_DEFAULT_SPACING;
+    clvRect.InsetBy(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+
+
+    fInterfaceListView = new BColumnListView(clvRect, "interface_clv",
+                                             B_FOLLOW_ALL_SIDES,
+                                             B_WILL_DRAW | B_NAVIGABLE,
+                                             B_PLAIN_BORDER, true);
+
+    fInterfaceListView->AddColumn(new BStringColumn("Name", 100, 50, 200, B_TRUNCATE_END), kInterfaceNameColumn);
+    fInterfaceListView->AddColumn(new BStringColumn("Type", 80, 40, 150, B_TRUNCATE_END), kInterfaceTypeColumn);
+    fInterfaceListView->AddColumn(new BStringColumn("Address", 120, 50, 300, B_TRUNCATE_END), kInterfaceAddressColumn);
+    fInterfaceListView->AddColumn(new BStringColumn("Sent", 90, 50, 200, B_TRUNCATE_END, B_ALIGN_RIGHT), kBytesSentColumn);
+    fInterfaceListView->AddColumn(new BStringColumn("Recv", 90, 50, 200, B_TRUNCATE_END, B_ALIGN_RIGHT), kBytesRecvColumn);
+    fInterfaceListView->AddColumn(new BStringColumn("TX Speed", 90, 50, 150, B_TRUNCATE_END, B_ALIGN_RIGHT), kSendSpeedColumn);
+    fInterfaceListView->AddColumn(new BStringColumn("RX Speed", 90, 50, 150, B_TRUNCATE_END, B_ALIGN_RIGHT), kRecvSpeedColumn);
+    // fInterfaceListView->AddColumn(new BStringColumn("Pkt Sent", 80, 40, 150, B_TRUNCATE_END, B_ALIGN_RIGHT), kPacketsSentColumn);
+    // fInterfaceListView->AddColumn(new BStringColumn("Pkt Recv", 80, 40, 150, B_TRUNCATE_END, B_ALIGN_RIGHT), kPacketsRecvColumn);
+    // fInterfaceListView->AddColumn(new BStringColumn("TX Err", 60, 30, 100, B_TRUNCATE_END, B_ALIGN_RIGHT), kSendErrorsColumn);
+    // fInterfaceListView->AddColumn(new BStringColumn("RX Err", 60, 30, 100, B_TRUNCATE_END, B_ALIGN_RIGHT), kRecvErrorsColumn);
+
+    fInterfaceListView->SetSortColumn(fInterfaceListView->ColumnAt(kInterfaceNameColumn), true, true);
+
+    BLayoutBuilder::Group<>(netBox, B_VERTICAL, 0)
+        .SetInsets(B_USE_DEFAULT_SPACING, fh.ascent + fh.descent + fh.leading + B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
+        .Add(fInterfaceListView);
+
+    BLayoutBuilder::Group<>(this, B_VERTICAL, 0)
+        .SetInsets(0)
+        .Add(netBox)
+    .End();
+
+    // Open a socket for ioctl calls (fallback or for certain info)
+    // BNetworkInterface and BNetworkRoster are preferred for modern Haiku.
+    fSocket = socket(AF_INET, SOCK_DGRAM, 0); // Or AF_LOCAL
+    // if (fSocket < 0) {
+    //     (new BAlert("NetworkView", "Failed to open socket for network stats.", "OK"))->Go(NULL);
+    // }
+}
+
+NetworkView::~NetworkView()
+{
+    if (fSocket >= 0) {
+        close(fSocket);
+    }
+    // fInterfaceListView is a child of netBox, auto-deleted.
+}
+
+void NetworkView::AttachedToWindow()
+{
+    UpdateData();
+    BView::AttachedToWindow();
+}
+
+void NetworkView::Pulse()
+{
+    UpdateData();
+}
+
+BString NetworkView::FormatBytes(uint64 bytes) {
+    BString str;
+    double kb = bytes / 1024.0;
+    double mb = kb / 1024.0;
+    double gb = mb / 1024.0;
+
+    if (gb >= 1.0) {
+        str.SetToFormat("%.2f GiB", gb);
+    } else if (mb >= 1.0) {
+        str.SetToFormat("%.2f MiB", mb);
+    } else if (kb >= 1.0) {
+        str.SetToFormat("%.1f KiB", kb);
+    } else {
+        str.SetToFormat("%llu B", bytes);
+    }
+    return str;
+}
+
+BString NetworkView::FormatSpeed(uint64 bytesDelta, bigtime_t microSecondsDelta) {
+    BString str;
+    if (microSecondsDelta <= 0) return "0 B/s";
+
+    double seconds = microSecondsDelta / 1000000.0;
+    double speed = bytesDelta / seconds; // Bytes per second
+
+    double kbs = speed / 1024.0;
+    double mbs = kbs / 1024.0;
+
+    if (mbs >= 1.0) {
+        str.SetToFormat("%.2f MiB/s", mbs);
+    } else if (kbs >= 1.0) {
+        str.SetToFormat("%.2f KiB/s", kbs);
+    } else {
+        str.SetToFormat("%.0f B/s", speed);
+    }
+    return str;
+}
+
+
+const char* NetworkView::GetInterfaceType(uint8 ifType) {
+    // From <net/if_types.h>
+    switch (ifType) {
+        case IFT_OTHER: return "Other";
+        case IFT_ETHER: return "Ethernet";
+        case IFT_ISO88025: return "TokenRing";
+        case IFT_FDDI: return "FDDI";
+        case IFT_PPP: return "PPP";
+        case IFT_SLIP: return "SLIP";
+        case IFT_LOOP: return "Loopback";
+        case IFT_IEEE80211: return "WiFi";
+        default: return "Unknown";
+    }
+}
+
+void NetworkView::UpdateData()
+{
+    fLocker.Lock();
+
+    // Clear existing rows (simple update strategy)
+    while (BRow* row = fInterfaceListView->RowAt(0)) {
+        fInterfaceListView->RemoveRow(row);
+        delete row;
+    }
+
+    BNetworkRoster& roster = BNetworkRoster::Default();
+    if (!roster.IsInstantiated()) {
+        // Handle error: roster not available
+        // (new BAlert("Network Error", "BNetworkRoster not available.", "OK"))->Go(NULL);
+        fLocker.Unlock();
+        return;
+    }
+
+    uint32 cookie = 0;
+    BNetworkInterface interface;
+
+    bigtime_t currentTime = system_time();
+
+    while (roster.GetNextInterface(&cookie, interface) == B_OK) {
+        BRow* row = new BRow();
+        row->SetField(new BStringField(interface.Name()), kInterfaceNameColumn);
+
+        // Get interface type (more reliable than flags for general type)
+        // This requires ioctl or other means if BNetworkInterface doesn't expose it easily.
+        // BNetworkInterface::Flags() can give IFF_LOOPBACK, IFF_POINTOPOINT.
+        // For physical type like Ethernet/WiFi, ioctl(SIOCGIFMEDIA) or similar is often used.
+        // Let's try to get it via ifreq for now if BNetworkInterface doesn't offer a direct type string.
+        ifreq ifr;
+        strncpy(ifr.ifr_name, interface.Name(), IFNAMSIZ -1);
+        ifr.ifr_name[IFNAMSIZ-1] = '\0';
+
+        // Type from BNetworkInterface (not directly available as string)
+        // We can use ioctl for more details.
+        // For now, a placeholder or deduce from flags.
+        BString typeStr = "N/A";
+        if (interface.Flags() & IFF_LOOPBACK) typeStr = "Loopback";
+        else if (interface.Flags() & IFF_POINTOPOINT) typeStr = "Point-to-Point";
+        // else could try SIOCGIFMEDIA or check common names like "eth", "wlan"
+        // For now, let's use this basic deduction.
+        // The GetInterfaceType function relies on if_data.ifi_type which comes from SIOCGIFDATA
+        // or similar low-level calls. BNetworkInterface is higher level.
+        // A more robust way is to use ifconfig output or the ioctl method.
+
+        if (fSocket >= 0) {
+            if (ioctl(fSocket, SIOCGIFTYPE, &ifr, sizeof(ifr)) == 0) {
+                 typeStr = GetInterfaceType(ifr.ifr_type);
+            } else if (ioctl(fSocket, SIOCGIFMEDIA, &ifr, sizeof(ifr)) == 0) { // Fallback using media
+                ifmr ifmr;
+                memcpy(ifmr.ifm_name, interface.Name(), IFNAMSIZ);
+                if (ioctl(fSocket, SIOCGIFXMEDIA, &ifmr, sizeof(ifmr)) == 0) {
+                    if (IFM_TYPE(ifmr.ifm_current) == IFM_ETHER) typeStr = "Ethernet";
+                    else if (IFM_TYPE(ifmr.ifm_current) == IFM_IEEE80211) typeStr = "WiFi";
+                    // Add more types based on IFM_TYPE definitions
+                }
+            }
+        }
+        row->SetField(new BStringField(typeStr), kInterfaceTypeColumn);
+
+
+        // Get first usable IP address (IPv4 or IPv6)
+        BString addressStr = "N/A";
+        for (int32 i = 0; i < interface.CountAddresses(); i++) {
+            BNetworkAddress addr = interface.AddressAt(i);
+            if (addr.Family() == AF_INET || addr.Family() == AF_INET6) {
+                if (!addr.IsLoopback() || (interface.Flags() & IFF_LOOPBACK) ) { // Show loopback addr for loopback iface
+                     addressStr = addr.ToString();
+                     break;
+                }
+            }
+        }
+        row->SetField(new BStringField(addressStr), kInterfaceAddressColumn);
+
+        // Statistics using SIOCGIFSTATS (or BNetworkInterface if it provided them)
+        // BNetworkInterface doesn't directly expose all raw counters like bytes/packets.
+        // We must use ioctl(SIOCGIFSTATS) for that.
+        uint64 bytesSent = 0, bytesRecv = 0, packetsSent = 0, packetsRecv = 0;
+        uint64 sendErrors = 0, recvErrors = 0;
+        BString sendSpeedStr = "0 B/s";
+        BString recvSpeedStr = "0 B/s";
+
+        if (fSocket >= 0) {
+            strncpy(ifr.ifr_name, interface.Name(), IFNAMSIZ -1);
+            ifr.ifr_name[IFNAMSIZ-1] = '\0';
+
+            if (ioctl(fSocket, SIOCGIFSTATS, &ifr, sizeof(ifr)) == 0) {
+                bytesSent = ifr.ifr_stats.ifi_obytes;
+                bytesRecv = ifr.ifr_stats.ifi_ibytes;
+                packetsSent = ifr.ifr_stats.ifi_opackets;
+                packetsRecv = ifr.ifr_stats.ifi_ipackets;
+                sendErrors = ifr.ifr_stats.ifi_oerrors;
+                recvErrors = ifr.ifr_stats.ifi_ierrors;
+
+                // Calculate speed
+                std::string ifNameStd = interface.Name();
+                if (gPreviousStatsMap.count(ifNameStd)) {
+                    InterfaceStatsRecord& prev = gPreviousStatsMap[ifNameStd];
+                    if (prev.lastUpdateTime > 0 && currentTime > prev.lastUpdateTime) {
+                        uint64 deltaSent = (bytesSent >= prev.bytesSent) ? (bytesSent - prev.bytesSent) : 0;
+                        uint64 deltaRecv = (bytesRecv >= prev.bytesReceived) ? (bytesRecv - prev.bytesReceived) : 0;
+                        bigtime_t deltaTime = currentTime - prev.lastUpdateTime;
+
+                        sendSpeedStr = FormatSpeed(deltaSent, deltaTime);
+                        recvSpeedStr = FormatSpeed(deltaRecv, deltaTime);
+                    }
+                }
+                // Update previous stats for next pulse
+                gPreviousStatsMap[ifNameStd].bytesSent = bytesSent;
+                gPreviousStatsMap[ifNameStd].bytesReceived = bytesRecv;
+                gPreviousStatsMap[ifNameStd].lastUpdateTime = currentTime;
+
+            } else {
+                // perror("ioctl SIOCGIFSTATS"); // For debugging
+            }
+        }
+
+        row->SetField(new BStringField(FormatBytes(bytesSent).String()), kBytesSentColumn);
+        row->SetField(new BStringField(FormatBytes(bytesRecv).String()), kBytesRecvColumn);
+        row->SetField(new BStringField(sendSpeedStr), kSendSpeedColumn);
+        row->SetField(new BStringField(recvSpeedStr), kRecvSpeedColumn);
+        // row->SetField(new BStringField(std::to_string(packetsSent).c_str()), kPacketsSentColumn);
+        // row->SetField(new BStringField(std::to_string(packetsRecv).c_str()), kPacketsRecvColumn);
+        // row->SetField(new BStringField(std::to_string(sendErrors).c_str()), kSendErrorsColumn);
+        // row->SetField(new BStringField(std::to_string(recvErrors).c_str()), kRecvErrorsColumn);
+
+        fInterfaceListView->AddRow(row);
+    }
+
+    fLocker.Unlock();
+}

--- a/haiku_port/NetworkView.h
+++ b/haiku_port/NetworkView.h
@@ -1,0 +1,76 @@
+#ifndef NETWORKVIEW_H
+#define NETWORKVIEW_H
+
+#include <View.h>
+#include <StringView.h>
+#include <Box.h>
+#include <ColumnListView.h>
+#include <Locker.h>
+
+// For network interface stats
+#include <sys/socket.h> // For AF_LINK, sockaddr_dl
+#include <net/if.h>     // For ifreq, IFNAMSIZ
+#include <net/if_dl.h>  // For sockaddr_dl
+#include <net/if_media.h> // For ifmediareq
+#include <net/if_types.h> // For IFT_*
+#include <arpa/inet.h>  // For inet_ntop
+#include <stdio.h>      // For snprintf
+#include <string.h>     // For strerror
+#include <unistd.h>     // For close() on socket
+#include <sys/ioctl.h>  // For ioctl commands like SIOCGIFSTATS, SIOCGIFCONF
+
+
+struct NetworkInterfaceInfo {
+    BString     name;
+    BString     type; // e.g., Ethernet, WiFi
+    BString     address; // IPv4 or IPv6
+    uint64      bytesSent;
+    uint64      bytesReceived;
+    uint64      packetsSent;
+    uint64      packetsReceived;
+    uint64      sendErrors;
+    uint64      recvErrors;
+    // Store previous values to calculate speed
+    bigtime_t   lastUpdateTime;
+    uint64      lastBytesSent;
+    uint64      lastBytesReceived;
+    BString     sendSpeed; // Formatted string (e.g., "KB/s")
+    BString     recvSpeed; // Formatted string
+};
+
+
+class NetworkView : public BView {
+public:
+    NetworkView(BRect frame);
+    ~NetworkView();
+
+    virtual void AttachedToWindow();
+    virtual void Pulse();
+
+private:
+    void UpdateData();
+    BString FormatBytes(uint64 bytes);
+    BString FormatSpeed(uint64 bytes, bigtime_t microSeconds);
+    const char* GetInterfaceType(uint8 ifType);
+
+    BColumnListView*    fInterfaceListView;
+    // We'll need a way to store info for multiple interfaces if present
+    // A BList of NetworkInterfaceInfo structs, or manage rows in CLV directly
+
+    // Map interface name to its struct to preserve speed calculation data
+    // This is simpler than managing BList indices if interfaces can appear/disappear
+    // However, Haiku's interface list is usually stable.
+    // For now, let's re-fetch and update all. A map might be useful for persistent stats.
+    // BMap<BString, NetworkInterfaceInfo> fInterfaceStatsMap;
+
+    // To keep track of previous stats for speed calculation for each interface
+    // A BList of NetworkInterfaceInfo, assuming interface order from SIOCGIFCONF is stable.
+    // Or, better, use a map from interface name to its previous state.
+    // For now, let's rebuild the list each time and calculate speed based on the last Pulse.
+    // This requires storing the previous stats *within* the BRow or a parallel structure.
+
+    BLocker fLocker;
+    int fSocket; // Socket for ioctl calls
+};
+
+#endif // NETWORKVIEW_H

--- a/haiku_port/ProcessView.cpp
+++ b/haiku_port/ProcessView.cpp
@@ -1,0 +1,328 @@
+#include "ProcessView.h"
+#include <LayoutBuilder.h>
+#include <ColumnTypes.h>
+#include <Button.h>
+#include <kernel/image.h> // For image_info, get_next_image_info for path
+#include <pwd.h>          // For getpwuid
+#include <signal.h>       // For kill()
+#include <Alert.h>
+#include <Roster.h>       // For be_roster->Launch to open terminal
+#include <Path.h>         // For BPath to find terminal
+
+#include <set> // To keep track of active PIDs for removal
+
+// Define column constants for BColumnListView
+enum {
+    kPIDColumn,
+    kProcessNameColumn,
+    kCPUUsageColumn,
+    kMemoryUsageColumn,
+    kThreadCountColumn,
+    kUserNameColumn,
+    kProcessPathColumn
+};
+
+// Context Menu Message
+const uint32 MSG_KILL_PROCESS = 'kill';
+const uint32 MSG_OPEN_TERMINAL_AT_PATH = 'otap'; // If we can get process path
+
+ProcessView::ProcessView(BRect frame)
+    : BView(frame, "ProcessView", B_FOLLOW_ALL_SIDES, B_WILL_DRAW | B_PULSE_NEEDED),
+      fLastPulseSystemTime(0)
+{
+    SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
+
+    BBox* procBox = new BBox("ProcessListBox");
+    procBox->SetLabel("Processes");
+
+    BRect clvRect = procBox->Bounds();
+    font_height fh;
+    procBox->GetFontHeight(&fh);
+    clvRect.top += fh.ascent + fh.descent + fh.leading + B_USE_DEFAULT_SPACING;
+    clvRect.InsetBy(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+
+    fProcessListView = new BColumnListView(clvRect, "process_clv",
+                                           B_FOLLOW_ALL_SIDES,
+                                           B_WILL_DRAW | B_NAVIGABLE,
+                                           B_PLAIN_BORDER, true);
+
+    fProcessListView->AddColumn(new BIntegerField("PID", 60, 30, 100), kPIDColumn);
+    fProcessListView->AddColumn(new BStringColumn("Name", 180, 50, 500, B_TRUNCATE_END), kProcessNameColumn);
+    fProcessListView->AddColumn(new BStringColumn("CPU %", 70, 40, 100, B_TRUNCATE_END, B_ALIGN_RIGHT), kCPUUsageColumn);
+    fProcessListView->AddColumn(new BStringColumn("Memory", 100, 50, 200, B_TRUNCATE_END, B_ALIGN_RIGHT), kMemoryUsageColumn);
+    fProcessListView->AddColumn(new BIntegerField("Threads", 60, 30, 100, B_ALIGN_RIGHT), kThreadCountColumn);
+    fProcessListView->AddColumn(new BStringColumn("User", 80, 40, 150, B_TRUNCATE_END), kUserNameColumn);
+    // fProcessListView->AddColumn(new BStringColumn("Path", 250, 50, 800, B_TRUNCATE_MIDDLE), kProcessPathColumn); // Path can be long
+
+    fProcessListView->SetSortColumn(fProcessListView->ColumnAt(kCPUUsageColumn), false, false); // Sort by CPU descending
+
+    // Context Menu
+    fContextMenu = new BPopUpMenu("ProcessContext", false, false);
+    fContextMenu->AddItem(new BMenuItem("Kill Process", new BMessage(MSG_KILL_PROCESS)));
+    // fContextMenu->AddItem(new BMenuItem("Open Terminal Here", new BMessage(MSG_OPEN_TERMINAL_AT_PATH))); // If path is available
+    fProcessListView->SetTarget(this); // For context menu messages if invoked directly on CLV
+                                       // However, CLV handles context menu via MouseDown hook.
+
+    BLayoutBuilder::Group<>(procBox, B_VERTICAL, 0)
+        .SetInsets(B_USE_DEFAULT_SPACING, fh.ascent + fh.descent + fh.leading + B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
+        .Add(fProcessListView);
+
+    BLayoutBuilder::Group<>(this, B_VERTICAL, 0)
+        .SetInsets(0)
+        .Add(procBox)
+    .End();
+}
+
+ProcessView::~ProcessView()
+{
+    delete fContextMenu;
+    // fProcessListView is child of procBox, auto-deleted
+}
+
+void ProcessView::AttachedToWindow()
+{
+    fProcessListView->SetTarget(this); // For selection messages and context menu
+    UpdateData();
+    fLastPulseSystemTime = system_time(); // Initialize for CPU calc
+    BView::AttachedToWindow();
+}
+
+void ProcessView::MessageReceived(BMessage* message)
+{
+    switch (message->what) {
+        case MSG_KILL_PROCESS:
+            KillSelectedProcess();
+            break;
+        // case MSG_OPEN_TERMINAL_AT_PATH:
+            // Implement if path is reliably obtained and useful
+            // break;
+        default:
+            BView::MessageReceived(message);
+            break;
+    }
+}
+
+
+void ProcessView::Pulse()
+{
+    UpdateData();
+}
+
+BString ProcessView::FormatBytes(uint64 bytes) {
+    BString str;
+    double kb = bytes / 1024.0;
+    double mb = kb / 1024.0;
+
+    if (mb >= 1.0) {
+        str.SetToFormat("%.1f MiB", mb);
+    } else if (kb >= 1.0) {
+        str.SetToFormat("%.0f KiB", kb);
+    } else {
+        str.SetToFormat("%llu B", bytes);
+    }
+    return str;
+}
+
+BString ProcessView::GetUserName(uid_t uid) {
+    struct passwd* pw = getpwuid(uid);
+    if (pw) {
+        return BString(pw->pw_name);
+    }
+    BString idStr;
+    idStr << uid;
+    return idStr; // Return UID as string if name not found
+}
+
+
+void ProcessView::ShowContextMenu(BPoint screenPoint) {
+    BRow* selectedRow = fProcessListView->CurrentSelection();
+    if (!selectedRow) return;
+
+    // Enable/disable items based on selection if needed
+    // Example: fContextMenu->FindItem(MSG_KILL_PROCESS)->SetEnabled(canKill);
+
+    fContextMenu->SetTargetForItems(this); // Messages will be sent to this ProcessView
+    fProcessListView->ConvertToScreen(&screenPoint);
+    fContextMenu->Go(screenPoint, true, true, true); // async, stay open for clicks
+}
+
+
+void ProcessView::KillSelectedProcess() {
+    BRow* selectedRow = fProcessListView->CurrentSelection();
+    if (!selectedRow) return;
+
+    BIntegerField* pidField = dynamic_cast<BIntegerField*>(selectedRow->GetField(kPIDColumn));
+    if (!pidField) return;
+
+    team_id team = pidField->Value();
+
+    BString alertMsg;
+    alertMsg.SetToFormat("Are you sure you want to kill process %d (%s)?",
+                         (int)team,
+                         ((BStringField*)selectedRow->GetField(kProcessNameColumn))->String());
+    BAlert* confirmAlert = new BAlert("Confirm Kill", alertMsg.String(), "Kill", "Cancel",
+                                      NULL, B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+    int32 button_index = confirmAlert->Go();
+
+    if (button_index == 0) { // "Kill" button
+        if (kill_team(team) != B_OK) { // or send_signal(team, SIGTERM); then SIGKILL
+            BAlert* errAlert = new BAlert("Error", "Failed to kill process.", "OK",
+                                          NULL, NULL, B_WIDTH_AS_USUAL, B_STOP_ALERT);
+            errAlert->Go();
+        } else {
+            // Optionally remove from list immediately or wait for next Pulse update
+            fProcessListView->RemoveRow(selectedRow);
+            delete selectedRow;
+            fProcessTimeMap.erase(team); // Remove from CPU tracking map
+        }
+    }
+}
+
+
+void ProcessView::UpdateData()
+{
+    fLocker.Lock();
+
+    // --- CPU Usage Calculation Setup ---
+    bigtime_t currentSystemTime = system_time();
+    bigtime_t systemTimeDelta = currentSystemTime - fLastPulseSystemTime;
+    if (systemTimeDelta <= 0) systemTimeDelta = 1; // Avoid division by zero or negative if time jumped
+
+    system_info sysInfo; // For CPU count
+    get_system_info(&sysInfo);
+    float totalPossibleCoreTime = sysInfo.cpu_count * systemTimeDelta;
+    if (totalPossibleCoreTime <=0) totalPossibleCoreTime = 1.0f; // Safety
+
+    // --- Prepare for Update: Mark existing rows or use a set of current PIDs ---
+    std::set<team_id> activePIDsThisPulse;
+
+
+    // --- Iterate Through Teams (Processes) ---
+    int32 cookie = 0;
+    team_info teamInfo;
+    while (get_next_team_info(&cookie, &teamInfo) == B_OK) {
+        activePIDsThisPulse.insert(teamInfo.team);
+
+        ProcessInfo currentProc;
+        currentProc.id = teamInfo.team;
+        strncpy(currentProc.name.LockBuffer(B_OS_NAME_LENGTH), teamInfo.args, B_OS_NAME_LENGTH);
+        currentProc.name.UnlockBuffer();
+        // teamInfo.args often contains full path + arguments. We might want to parse just the executable name.
+        // For simplicity, using args directly first. A more robust way is to get image_info.
+        image_info imgInfo;
+        int32 imgCookie = 0;
+        if (get_next_image_info(teamInfo.team, &imgCookie, &imgInfo) == B_OK) {
+            currentProc.name = BPath(&imgInfo.name).Leaf(); // Get executable name
+            currentProc.path = imgInfo.name;
+        } else {
+             // Fallback if no image info (e.g. kernel threads or special processes)
+            if (currentProc.name.Length() == 0) currentProc.name = "system_daemon";
+        }
+
+
+        currentProc.threadCount = teamInfo.thread_count;
+        currentProc.areaCount = teamInfo.area_count; // Not directly memory usage yet
+        currentProc.userID = teamInfo.uid;
+        currentProc.userName = GetUserName(currentProc.userID);
+        currentProc.totalKernelTime = teamInfo.kernel_time;
+        currentProc.totalUserTime = teamInfo.user_time;
+
+
+        // --- Calculate Memory Usage ---
+        // Sum sizes of all areas owned by the team
+        // This is a simplification; actual resident/shared memory is more complex.
+        currentProc.memoryUsageBytes = 0;
+        area_info areaInfo;
+        int32 areaCookie = 0;
+        while (get_next_area_info(teamInfo.team, &areaCookie, &areaInfo) == B_OK) {
+            currentProc.memoryUsageBytes += areaInfo.ram_size; // ram_size is closer to resident
+        }
+
+
+        // --- Calculate CPU Usage ---
+        float cpuPercent = 0.0f;
+        if (fProcessTimeMap.count(currentProc.id)) {
+            ProcessInfo& prevProc = fProcessTimeMap[currentProc.id];
+            bigtime_t procKernelDelta = currentProc.totalKernelTime - prevProc.totalKernelTime;
+            bigtime_t procUserDelta = currentProc.totalUserTime - prevProc.totalUserTime;
+            bigtime_t procTotalTimeDelta = procKernelDelta + procUserDelta;
+
+            if (procTotalTimeDelta < 0) procTotalTimeDelta = 0; // Time can jump backwards if process restarts with same PID quickly
+
+            cpuPercent = (float)procTotalTimeDelta / totalPossibleCoreTime * 100.0f;
+            // This uses total system time delta * cpu_count as denominator.
+            // Alternative: (float)procTotalTimeDelta / systemTimeDelta * 100.0f; (for single core equivalent percent)
+            // For multi-core view (like top), the first is more standard.
+            if (cpuPercent < 0.0f) cpuPercent = 0.0f;
+            // if (cpuPercent > 100.0f * sysInfo.cpu_count) cpuPercent = 100.0f * sysInfo.cpu_count; // Clamp to max possible
+            if (cpuPercent > 100.0f) cpuPercent = 100.0f; // If using the per-core normalized percentage
+        }
+        currentProc.cpuUsage = cpuPercent;
+
+        // Store current times for next calculation
+        fProcessTimeMap[currentProc.id].totalKernelTime = currentProc.totalKernelTime;
+        fProcessTimeMap[currentProc.id].totalUserTime = currentProc.totalUserTime;
+        // Other fields of ProcessInfo in map are updated if needed, or just use it for times.
+
+
+        // --- Find or Create Row in BColumnListView ---
+        BRow* row = NULL;
+        for (int32 i = 0; (row = fProcessListView->RowAt(i)) != NULL; i++) {
+            BIntegerField* pidField = dynamic_cast<BIntegerField*>(row->GetField(kPIDColumn));
+            if (pidField && pidField->Value() == currentProc.id) {
+                break; // Found existing row
+            }
+        }
+
+        if (row == NULL) { // New process, add a row
+            row = new BRow();
+            row->SetField(new BIntegerField(currentProc.id), kPIDColumn);
+            row->SetField(new BStringField(currentProc.name.String()), kProcessNameColumn);
+
+            char cpuStr[16]; // For CPU %
+            snprintf(cpuStr, sizeof(cpuStr), "%.1f", currentProc.cpuUsage);
+            row->SetField(new BStringField(cpuStr), kCPUUsageColumn);
+
+            row->SetField(new BStringField(FormatBytes(currentProc.memoryUsageBytes).String()), kMemoryUsageColumn);
+            row->SetField(new BIntegerField(currentProc.threadCount), kThreadCountColumn);
+            row->SetField(new BStringField(currentProc.userName.String()), kUserNameColumn);
+            // row->SetField(new BStringField(currentProc.path.String()), kProcessPathColumn);
+            fProcessListView->AddRow(row);
+        } else { // Existing process, update fields
+            ((BStringField*)row->GetField(kProcessNameColumn))->SetString(currentProc.name.String());
+
+            char cpuStr[16];
+            snprintf(cpuStr, sizeof(cpuStr), "%.1f", currentProc.cpuUsage);
+            ((BStringField*)row->GetField(kCPUUsageColumn))->SetString(cpuStr);
+
+            ((BStringField*)row->GetField(kMemoryUsageColumn))->SetString(FormatBytes(currentProc.memoryUsageBytes).String());
+            ((BIntegerField*)row->GetField(kThreadCountColumn))->SetValue(currentProc.threadCount);
+            ((BStringField*)row->GetField(kUserNameColumn))->SetString(currentProc.userName.String());
+            // ((BStringField*)row->GetField(kProcessPathColumn))->SetString(currentProc.path.String());
+            fProcessListView->UpdateRow(row);
+        }
+    }
+
+    // --- Remove Rows for Processes That No Longer Exist ---
+    for (int32 i = 0; (i < fProcessListView->CountRows()); ) {
+        BRow* row = fProcessListView->RowAt(i);
+        BIntegerField* pidField = dynamic_cast<BIntegerField*>(row->GetField(kPIDColumn));
+        if (pidField) {
+            if (activePIDsThisPulse.find(pidField->Value()) == activePIDsThisPulse.end()) {
+                // PID in list view is not in current active PIDs, remove it
+                fProcessTimeMap.erase(pidField->Value()); // Clean up CPU map
+                fProcessListView->RemoveRow(row);
+                delete row;
+                continue; // Don't increment i, as rows shifted
+            }
+        }
+        i++;
+    }
+
+    // Re-sort if needed (e.g., if sort column is CPU and values changed)
+    fProcessListView->SortItems();
+
+
+    fLastPulseSystemTime = currentSystemTime;
+    fLocker.Unlock();
+}

--- a/haiku_port/ProcessView.h
+++ b/haiku_port/ProcessView.h
@@ -1,0 +1,69 @@
+#ifndef PROCESSVIEW_H
+#define PROCESSVIEW_H
+
+#include <View.h>
+#include <ColumnListView.h>
+#include <Locker.h>
+#include <String.h>
+#include <kernel/OS.h> // For team_info, thread_info, get_team_info etc.
+#include <PopUpMenu.h>
+#include <MenuItem.h>
+
+// For CPU usage calculation
+#include <map>
+
+struct ProcessInfo {
+    team_id     id;
+    BString     name;
+    BString     path; // Full path to executable
+    int32       threadCount;
+    int32       areaCount; // Number of memory areas
+    uint64      memoryUsageBytes; // Sum of area sizes
+    float       cpuUsage; // Percentage
+    uid_t       userID;
+    BString     userName;
+
+    // For CPU usage calculation over time
+    bigtime_t   totalKernelTime;
+    bigtime_t   totalUserTime;
+    bigtime_t   lastPollKernelTime;
+    bigtime_t   lastPollUserTime;
+    bigtime_t   lastPollSystemTime; // system_time() at last poll for this process
+
+    ProcessInfo() : id(0), threadCount(0), areaCount(0), memoryUsageBytes(0), cpuUsage(0.0f),
+                    userID(0), totalKernelTime(0), totalUserTime(0),
+                    lastPollKernelTime(0), lastPollUserTime(0), lastPollSystemTime(0) {}
+};
+
+
+// Map to store previous CPU times for processes for usage calculation.
+// Key: team_id, Value: ProcessInfo (containing previous times)
+typedef std::map<team_id, ProcessInfo> ProcessTimeMap;
+
+
+class ProcessView : public BView {
+public:
+    ProcessView(BRect frame);
+    ~ProcessView();
+
+    virtual void AttachedToWindow();
+    virtual void Pulse();
+    virtual void MessageReceived(BMessage* message); // For context menu actions
+
+private:
+    void UpdateData();
+    BString FormatBytes(uint64 bytes);
+    BString GetUserName(uid_t uid);
+    void ShowContextMenu(BPoint screenPoint);
+    void KillSelectedProcess();
+
+
+    BColumnListView*    fProcessListView;
+    BPopUpMenu*         fContextMenu;
+    BLocker             fLocker;
+
+    ProcessTimeMap      fProcessTimeMap; // Stores info for CPU usage calculation
+    bigtime_t           fLastPulseSystemTime; // system_time() at the last global pulse
+};
+
+#endif // PROCESSVIEW_H

--- a/haiku_port/SysInfoView.cpp
+++ b/haiku_port/SysInfoView.cpp
@@ -1,0 +1,433 @@
+#include "SysInfoView.h"
+#include <kernel/OS.h>      // For system_info, get_system_info, get_cpu_info
+#include <Screen.h>         // For BScreen, accelerant_device_info
+#include <GraphicsDefs.h>   // For accelerant_device_info
+#include <VolumeRoster.h>   // For BVolumeRoster
+#include <Volume.h>         // For BVolume
+#include <fs_info.h>        // For fs_info
+#include <driver_settings.h> // For parsing CPU features (if available this way)
+#include <stdio.h>          // For snprintf
+#include <time.h>           // For ctime, strftime for build date
+#include <TextView.h>       // For BTextView
+#include <String.h>
+#include <Alignment.h>
+#include <SpaceLayoutItem.h>
+#include <Font.h>
+
+// Helper to add a labeled string view to a grid layout
+static void AddInfoRow(BGridLayout* grid, int32& row, const char* labelText, BStringView*& valueView) {
+    BStringView* labelView = new BStringView(NULL, labelText); // Name can be null for labels not needing lookup
+    labelView->SetAlignment(B_ALIGN_RIGHT);
+    grid->AddView(labelView, 0, row);
+    valueView = new BStringView(NULL, "N/A"); // Value placeholder
+    grid->AddView(valueView, 1, row);
+    grid->AddItem(BSpaceLayoutItem::CreateHorizontalStrut(5), 2, row); // Spacer
+    row++;
+}
+
+
+SysInfoView::SysInfoView(BRect frame)
+    : BView(frame, "SysInfoView", B_FOLLOW_ALL_SIDES, B_WILL_DRAW),
+      fDiskInfoTextView(NULL), fDiskInfoScrollView(NULL), fMainSectionsBox(NULL)
+{
+    SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
+    CreateLayout();
+}
+
+SysInfoView::~SysInfoView()
+{
+    // Child views are automatically deleted by parent
+}
+
+void SysInfoView::CreateLayout()
+{
+    fMainSectionsBox = new BBox(Bounds(), "mainSysInfoBox", B_FOLLOW_ALL_SIDES, B_WILL_DRAW | B_FRAME_EVENTS, B_PLAIN_BORDER);
+    fMainSectionsBox->SetLabel("System Information");
+
+    // --- OS Section ---
+    BBox* osBox = new BBox("OSInfo");
+    osBox->SetLabel("Operating System");
+    BGridLayout* osGrid = new BGridLayout(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    osGrid->SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    int32 row = 0;
+    AddInfoRow(osGrid, row, "Kernel Name:", fKernelNameValue);
+    AddInfoRow(osGrid, row, "Kernel Version:", fKernelVersionValue);
+    AddInfoRow(osGrid, row, "Build Date/Time:", fKernelBuildValue);
+    AddInfoRow(osGrid, row, "CPU Architecture:", fCPUArchValue);
+    AddInfoRow(osGrid, row, "System Uptime:", fUptimeValue);
+    osBox->AddChild(osGrid->View());
+
+    // --- CPU Section ---
+    BBox* cpuBox = new BBox("CPUInfo");
+    cpuBox->SetLabel("Processor");
+    BGridLayout* cpuGrid = new BGridLayout(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    cpuGrid->SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    row = 0;
+    AddInfoRow(cpuGrid, row, "Model:", fCPUModelValue);
+    AddInfoRow(cpuGrid, row, "Cores:", fCPUCoresValue);
+    AddInfoRow(cpuGrid, row, "Clock Speed:", fCPUClockSpeedValue);
+    AddInfoRow(cpuGrid, row, "L1 Cache (I/D):", fL1CacheValue);
+    AddInfoRow(cpuGrid, row, "L2 Cache:", fL2CacheValue);
+    AddInfoRow(cpuGrid, row, "L3 Cache:", fL3CacheValue);
+    AddInfoRow(cpuGrid, row, "Features:", fCPUFeaturesValue);
+    fCPUFeaturesValue->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET)); // Allow to wrap if needed
+    cpuBox->AddChild(cpuGrid->View());
+
+    // --- Graphics Section ---
+    BBox* graphicsBox = new BBox("GraphicsInfo");
+    graphicsBox->SetLabel("Graphics");
+    BGridLayout* graphicsGrid = new BGridLayout(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    graphicsGrid->SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    row = 0;
+    AddInfoRow(graphicsGrid, row, "GPU Type:", fGPUTypeValue);
+    AddInfoRow(graphicsGrid, row, "Driver:", fGPUDriverValue);
+    AddInfoRow(graphicsGrid, row, "VRAM:", fGPUVRAMValue);
+    AddInfoRow(graphicsGrid, row, "Resolution:", fScreenResolutionValue);
+    graphicsBox->AddChild(graphicsGrid->View());
+
+    // --- Memory Section ---
+    BBox* memoryBox = new BBox("MemoryInfo");
+    memoryBox->SetLabel("Memory");
+    BGridLayout* memoryGrid = new BGridLayout(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    memoryGrid->SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    row = 0;
+    AddInfoRow(memoryGrid, row, "Total RAM:", fTotalRAMValue);
+    memoryBox->AddChild(memoryGrid->View());
+
+    // --- Disk Section ---
+    BBox* diskBox = new BBox("DiskInfo");
+    diskBox->SetLabel("Disk Volumes");
+    fDiskInfoTextView = new BTextView("diskInfoTextView");
+    fDiskInfoTextView->SetWordWrap(false);
+    fDiskInfoTextView->MakeEditable(false);
+    fDiskInfoTextView->SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR)); // Match background
+    fDiskInfoScrollView = new BScrollView("diskInfoScroller", fDiskInfoTextView, B_FOLLOW_LEFT_RIGHT | B_FOLLOW_TOP_BOTTOM, 0, false, true, B_PLAIN_BORDER); // Horizontal scrollbar off
+    fDiskInfoScrollView->SetExplicitMinSize(BSize(0, 80)); // Give it some min height
+
+    BLayoutBuilder::Group<>(diskBox, B_VERTICAL, 0)
+        .SetInsets(B_USE_DEFAULT_SPACING) // Insets for the box content
+        .Add(fDiskInfoScrollView);
+
+
+    // Add all sections to the main box's layout manager
+    // Using a BGroupLayout for the fMainSectionsBox to hold other boxes vertically
+    BGroupLayout* mainGroupLayout = new BGroupLayout(B_VERTICAL, B_USE_DEFAULT_SPACING);
+    fMainSectionsBox->SetLayout(mainGroupLayout); // Set layout for the main box
+    mainGroupLayout->SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+    // Add a B_USE_WINDOW_INSETS like value for the top if BBox label is drawn
+    font_height fh;
+    fMainSectionsBox->GetFontHeight(&fh);
+    mainGroupLayout->SetInsets(B_USE_DEFAULT_SPACING, fh.ascent + fh.descent + fh.leading + B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING);
+
+
+    mainGroupLayout->AddView(osBox);
+    mainGroupLayout->AddView(cpuBox);
+    mainGroupLayout->AddView(graphicsBox);
+    mainGroupLayout->AddView(memoryBox);
+    mainGroupLayout->AddView(diskBox);
+    mainGroupLayout->AddGlue(); // Push all content to the top
+
+    // The SysInfoView itself will contain a ScrollView that contains fMainSectionsBox
+    // This allows the entire content to be scrollable if it exceeds the view height.
+    BScrollView* viewScroller = new BScrollView("sysInfoScroller", fMainSectionsBox, B_FOLLOW_ALL_SIDES, 0, false, true, B_NO_BORDER);
+
+    BLayoutBuilder::Group<>(this, B_VERTICAL, 0)
+        .SetInsets(0) // No insets for the top BView, scroller handles it.
+        .Add(viewScroller)
+    .End();
+}
+
+
+void SysInfoView::AttachedToWindow()
+{
+    BView::AttachedToWindow();
+    LoadData(); // Load data when view is attached
+}
+
+// Helper Formatters
+BString SysInfoView::FormatBytes(uint64 bytes, int precision) {
+    BString str;
+    double kb = bytes / 1024.0;
+    double mb = kb / 1024.0;
+    double gb = mb / 1024.0;
+
+    if (gb >= 1.0) {
+        str.SetToFormat("%.*f GiB", precision, gb);
+    } else if (mb >= 1.0) {
+        str.SetToFormat("%.*f MiB", precision, mb);
+    } else if (kb >= 1.0) {
+        str.SetToFormat("%.*f KiB", precision, kb);
+    } else {
+        str.SetToFormat("%llu Bytes", bytes);
+    }
+    return str;
+}
+
+BString SysInfoView::FormatHertz(uint64 hertz) {
+    BString str;
+    double ghz = hertz / 1000000000.0;
+    double mhz = hertz / 1000000.0;
+    double khz = hertz / 1000.0;
+
+    if (ghz >= 1.0) {
+        str.SetToFormat("%.2f GHz", ghz);
+    } else if (mhz >= 1.0) {
+        str.SetToFormat("%.0f MHz", mhz);
+    } else if (khz >= 1.0) {
+        str.SetToFormat("%.0f KHz", khz);
+    } else {
+        str.SetToFormat("%llu Hz", hertz);
+    }
+    return str;
+}
+
+BString SysInfoView::FormatUptime(bigtime_t bootTime) {
+    bigtime_t now = system_time();
+    bigtime_t uptimeMicros = now - bootTime;
+    uint32 seconds = uptimeMicros / 1000000;
+
+    uint32 days = seconds / (24 * 3600);
+    seconds %= (24 * 3600);
+    uint32 hours = seconds / 3600;
+    seconds %= 3600;
+    uint32 minutes = seconds / 60;
+    seconds %= 60;
+
+    BString uptimeStr;
+    if (days > 0) {
+        uptimeStr.SetToFormat("%u days, %02u:%02u:%02u", days, hours, minutes, seconds);
+    } else {
+        uptimeStr.SetToFormat("%02u:%02u:%02u", hours, minutes, seconds);
+    }
+    return uptimeStr;
+}
+
+BString SysInfoView::GetCPUFeatureFlags() {
+    BString featuresStr;
+    uint32 features = 0;
+    uint32 extendedFeatures = 0;
+
+    if (get_cpu_features(&features) != B_OK) {
+        // featuresStr += "Features N/A; ";
+    }
+    if (get_extended_cpu_features(&extendedFeatures) != B_OK) {
+        // featuresStr += "Ext Features N/A";
+    }
+
+    // Check for common SIMD features first
+    if (features & B_CPU_FEATURE_MMX) featuresStr += "MMX ";
+    if (features & B_CPU_FEATURE_SSE) featuresStr += "SSE ";
+    if (features & B_CPU_FEATURE_SSE2) featuresStr += "SSE2 ";
+    if (extendedFeatures & B_CPU_EXT_FEATURE_SSE3) featuresStr += "SSE3 "; // B_CPU_FEATURE_SSE3 in some headers
+    if (extendedFeatures & B_CPU_EXT_FEATURE_SSSE3) featuresStr += "SSSE3 ";
+    if (extendedFeatures & B_CPU_EXT_FEATURE_SSE4_1) featuresStr += "SSE4.1 ";
+    if (extendedFeatures & B_CPU_EXT_FEATURE_SSE4_2) featuresStr += "SSE4.2 ";
+    if (extendedFeatures & B_CPU_EXT_FEATURE_AVX) featuresStr += "AVX ";
+    if (extendedFeatures & B_CPU_EXT_FEATURE_AVX2) featuresStr += "AVX2 ";
+    // Add more common features as desired
+    // if (features & B_CPU_FEATURE_FPU) featuresStr += "FPU ";
+    // if (features & B_CPU_FEATURE_TSC) featuresStr += "TSC ";
+    // if (features & B_CPU_FEATURE_CMOV) featuresStr += "CMOV ";
+    // if (extendedFeatures & B_CPU_EXT_FEATURE_ABM) featuresStr += "ABM "; // (LZCNT)
+    // if (extendedFeatures & B_CPU_EXT_FEATURE_AES) featuresStr += "AES ";
+    // if (extendedFeatures & B_CPU_EXT_FEATURE_RDRAND) featuresStr += "RDRAND ";
+
+
+    if (featuresStr.Length() == 0) {
+        featuresStr = "N/A or no common features detected";
+    }
+    return featuresStr.Trim();
+}
+
+
+void SysInfoView::LoadData() {
+    system_info sysInfo;
+    if (get_system_info(&sysInfo) == B_OK) {
+        // --- OS Info ---
+        fKernelNameValue->SetText(sysInfo.kernel_name);
+
+        BString kernelVer;
+        kernelVer.SetToFormat("%s (API %lu)", sysInfo.kernel_version, sysInfo.abi);
+        fKernelVersionValue->SetText(kernelVer);
+
+        char buildDateTime[100];
+        struct tm build_tm;
+        localtime_r(&sysInfo.kernel_build_time, &build_tm); // kernel_build_time is time_t
+        strftime(buildDateTime, sizeof(buildDateTime), "%Y-%m-%d %H:%M:%S", &build_tm);
+        fKernelBuildValue->SetText(buildDateTime);
+
+        const char* arch = "Unknown";
+        #if __x86_64__
+            arch = "x86_64";
+        #elif __INTEL__ // For x86 (32-bit)
+            arch = "x86 (32-bit)";
+        #elif __POWERPC__
+            arch = "PowerPC";
+        #elif __ARM__
+            arch = "ARM";
+        #elif __M68K__
+            arch = "m68k";
+        #endif
+        // sysInfo.architecture might also provide a string on some Haiku versions/builds
+        fCPUArchValue->SetText(arch);
+
+        fUptimeValue->SetText(FormatUptime(sysInfo.boot_time).String());
+
+        // --- CPU Info ---
+        // Note: cpu_info is an array. For simplicity, showing info for the first CPU.
+        // A more complex UI could list all CPUs if heterogeneous or desired.
+        if (sysInfo.cpu_count > 0) {
+            cpu_info cpuInfo = sysInfo.cpu_infos[0]; // Info for the first core/package
+
+            // Construct a CPU model string if Haiku doesn't provide one directly
+            // Some Haiku versions might populate cpu_info.model_name or similar.
+            // If not, we try to get it from kernel args or a known location if any.
+            // For now, using sysInfo.cpu_type which is often a generic type.
+            // The actual "brand string" might not be easily available without parsing /dev/cpu/*
+            // or specific low-level mechanisms not in system_info.
+            // The kernel might store the brand string in sysInfo.cpu_type or similar.
+            // For now, we use what's available in system_info.
+            BString cpuModelString;
+            // cpu_info.model_name is not standard in BeOS R5 system_info, might be Haiku specific.
+            // Check if sysInfo.cpu_type itself is descriptive enough
+            if (strlen(sysInfo.cpu_type) > 0 ) { // cpu_type is char array in system_info
+                 cpuModelString = sysInfo.cpu_type;
+            } else {
+                cpuModelString = "N/A"; // Fallback
+            }
+            fCPUModelValue->SetText(cpuModelString);
+
+
+            BString coreStr;
+            coreStr << sysInfo.cpu_count;
+            fCPUCoresValue->SetText(coreStr);
+            fCPUClockSpeedValue->SetText(FormatHertz(sysInfo.cpu_clock_speed).String());
+
+            // Cache sizes (L1 is often per core, L2/L3 can be shared or per core)
+            // Summing for simplicity if per-core details are too verbose for this view
+            uint64 totalL1i = 0, totalL1d = 0, totalL2 = 0, totalL3 = 0;
+            for (uint32 i = 0; i < sysInfo.cpu_count; ++i) {
+                totalL1i += sysInfo.cpu_infos[i].l1_cache_size; // L1I often not in cpu_info directly, might be combined
+                totalL1d += sysInfo.cpu_infos[i].l1_cache_size; // Assuming l1_cache_size is L1D or combined L1
+                                                                // Haiku's cpu_info has l1_icache_size, l1_dcache_size, l2_cache_size, l3_cache_size
+                                                                // but these might not be in the older BeOS compatible system_info struct directly.
+                                                                // Let's assume system_info is extended or use get_cpu_info if needed
+            }
+            // For a more accurate modern Haiku approach:
+            // get_cpu_info(B_CPU_TCB, 0, &cpuSpecificInfo) might be better.
+            // For now, stick to what's in system_info.cpu_infos[0] for simplicity
+            // if these fields (l1_icache_size etc.) are indeed Haiku extensions to cpu_info.
+            // The BeBook cpu_info has:
+            // uint32	l1_cache_size;	/* size of L1 cache */
+            // uint32	l2_cache_size;	/* size of L2 cache */
+            // uint32	l3_cache_size;	/* size of L3 cache */
+            // Haiku likely extended this with separate I/D cache sizes.
+            // Let's assume sysInfo.cpu_infos[0] has the extended fields for now.
+            // If not, these will be 0.
+            BString l1Str, l2Str, l3Str;
+            if (sysInfo.cpu_infos[0].l1_icache_size > 0 || sysInfo.cpu_infos[0].l1_dcache_size > 0) {
+                 l1Str.SetToFormat("%s I / %s D (per core avg)",
+                                FormatBytes(sysInfo.cpu_infos[0].l1_icache_size,0).String(),
+                                FormatBytes(sysInfo.cpu_infos[0].l1_dcache_size,0).String());
+            } else if (sysInfo.cpu_infos[0].l1_cache_size > 0) { // Fallback to combined L1
+                 l1Str.SetToFormat("%s (per core avg)", FormatBytes(sysInfo.cpu_infos[0].l1_cache_size,0).String());
+            } else {
+                l1Str = "N/A";
+            }
+
+            if(sysInfo.cpu_infos[0].l2_cache_size > 0)
+                l2Str.SetToFormat("%s", FormatBytes(sysInfo.cpu_infos[0].l2_cache_size,0).String());
+            else l2Str = "N/A";
+
+            if(sysInfo.cpu_infos[0].l3_cache_size > 0)
+                l3Str.SetToFormat("%s", FormatBytes(sysInfo.cpu_infos[0].l3_cache_size,0).String());
+            else l3Str = "N/A";
+
+            fL1CacheValue->SetText(l1Str);
+            fL2CacheValue->SetText(l2Str);
+            fL3CacheValue->SetText(l3Str);
+
+            fCPUFeaturesValue->SetText(GetCPUFeatureFlags().String());
+        } else {
+            fCPUModelValue->SetText("N/A");
+            fCPUCoresValue->SetText("N/A");
+            fCPUClockSpeedValue->SetText("N/A");
+            fL1CacheValue->SetText("N/A");
+            fL2CacheValue->SetText("N/A");
+            fL3CacheValue->SetText("N/A");
+            fCPUFeaturesValue->SetText("N/A");
+        }
+
+        // --- Memory Info ---
+        fTotalRAMValue->SetText(FormatBytes( (uint64)sysInfo.max_pages * B_PAGE_SIZE ).String());
+
+    } else {
+        // Handle error getting system_info
+        const char* errorMsg = "Error fetching system info";
+        fKernelNameValue->SetText(errorMsg);
+        // ... set all other fields to error or N/A
+    }
+
+    // --- Graphics Info ---
+    BScreen screen(B_MAIN_SCREEN_ID);
+    if (screen.IsValid()) {
+        accelerant_device_info deviceInfo;
+        if (screen.GetDeviceInfo(&deviceInfo) == B_OK) {
+            fGPUTypeValue->SetText(deviceInfo.name);
+            BString driverVerStr;
+            driverVerStr << deviceInfo.version; // Version is uint32
+            fGPUDriverValue->SetText(driverVerStr);
+            fGPUVRAMValue->SetText(FormatBytes(deviceInfo.memory).String());
+        } else {
+            fGPUTypeValue->SetText("Error getting GPU info");
+            fGPUDriverValue->SetText("N/A");
+            fGPUVRAMValue->SetText("N/A");
+        }
+        BRect frame = screen.Frame();
+        BString resStr;
+        resStr.SetToFormat("%.0fx%.0f", frame.Width() + 1, frame.Height() + 1);
+        fScreenResolutionValue->SetText(resStr);
+    } else {
+        fGPUTypeValue->SetText("Error: Invalid screen object");
+        fGPUDriverValue->SetText("N/A");
+        fGPUVRAMValue->SetText("N/A");
+        fScreenResolutionValue->SetText("N/A");
+    }
+
+    // --- Disk Info ---
+    BString diskTextData;
+    BVolumeRoster volRoster;
+    BVolume volume;
+    volRoster.Rewind();
+    int diskCount = 0;
+    while (volRoster.GetNextVolume(&volume) == B_OK) {
+        if (!volume.KnowsCapacity()) continue; // Skip virtual/non-capacity volumes
+        diskCount++;
+        fs_info fsInfo;
+        if (fs_stat_dev(volume.Device(), &fsInfo) == B_OK) {
+            if (diskTextData.Length() > 0) diskTextData << "\n---\n"; // Separator
+            diskTextData << "Volume Name: " << fsInfo.volume_name << "\n";
+
+            BDirectory rootDir;
+            volume.GetRootDirectory(&rootDir);
+            BEntry entry;
+            rootDir.GetEntry(&entry);
+            BPath path;
+            entry.GetPath(&path);
+            diskTextData << "Mount Point: " << path.Path() << "\n";
+
+            diskTextData << "File System: " << fsInfo.fsh_name << "\n";
+            diskTextData << "Total Size: " << FormatBytes(fsInfo.total_blocks * fsInfo.block_size).String() << "\n";
+            diskTextData << "Free Size: " << FormatBytes(fsInfo.free_blocks * fsInfo.block_size).String();
+            // Determining physical type (USB, SATA, HDD/SSD) is complex and generally
+            // not available from BVolume/fs_info directly. Would require deeper device querying.
+        }
+    }
+    if (diskCount == 0) {
+        diskTextData = "No disk volumes found or accessible.";
+    }
+    fDiskInfoTextView->SetText(diskTextData.String());
+}
+
+// Dummy main for syntax checking if compiled standalone (remove for project)
+// int main() { return 0; }

--- a/haiku_port/SysInfoView.h
+++ b/haiku_port/SysInfoView.h
@@ -1,0 +1,86 @@
+#ifndef SYSINFOVIEW_H
+#define SYSINFOVIEW_H
+
+#include <View.h>
+#include <StringView.h>
+#include <Box.h>
+#include <GridLayout.h>
+#include <GroupLayout.h>
+#include <ScrollView.h> // In case content becomes too long
+
+// Forward declare BTextView if used for multi-line disk info
+class BTextView;
+
+class SysInfoView : public BView {
+public:
+    SysInfoView(BRect frame);
+    ~SysInfoView();
+
+    virtual void AttachedToWindow();
+
+private:
+    void CreateLayout(); // Helper to set up the UI elements
+    void LoadData();     // Helper to fetch and display data
+
+    BString FormatBytes(uint64 bytes, int precision = 1);
+    BString FormatHertz(uint64 hertz);
+    BString FormatUptime(bigtime_t bootTime);
+    BString GetCPUFeatureFlags();
+
+
+    // --- OS Information ---
+    BStringView* fKernelNameLabel;
+    BStringView* fKernelNameValue;
+    BStringView* fKernelVersionLabel;
+    BStringView* fKernelVersionValue;
+    BStringView* fKernelBuildLabel;
+    BStringView* fKernelBuildValue;
+    BStringView* fCPUArchLabel;
+    BStringView* fCPUArchValue;
+    BStringView* fUptimeLabel;
+    BStringView* fUptimeValue;
+
+    // --- CPU Information ---
+    BStringView* fCPUModelLabel;
+    BStringView* fCPUModelValue;
+    BStringView* fCPUCoresLabel;
+    BStringView* fCPUCoresValue;
+    BStringView* fCPUClockSpeedLabel;
+    BStringView* fCPUClockSpeedValue;
+    BStringView* fCPUFeaturesLabel; // For SIMD etc.
+    BStringView* fCPUFeaturesValue;
+    // Cache Info
+    BStringView* fL1CacheLabel;
+    BStringView* fL1CacheValue;
+    BStringView* fL2CacheLabel;
+    BStringView* fL2CacheValue;
+    BStringView* fL3CacheLabel;
+    BStringView* fL3CacheValue;
+
+    // --- Graphics Information ---
+    BStringView* fGPUTypeLabel; // e.g. Card Name from accelerant
+    BStringView* fGPUTypeValue;
+    BStringView* fGPUDriverLabel;
+    BStringView* fGPUDriverValue;
+    BStringView* fGPUVRAMLabel;
+    BStringView* fGPUVRAMValue;
+    BStringView* fScreenResolutionLabel;
+    BStringView* fScreenResolutionValue;
+
+    // --- Memory Information ---
+    BStringView* fTotalRAMLabel;
+    BStringView* fTotalRAMValue;
+
+    // --- Disk Information ---
+    // This might be better as a BTextView or dynamically added BStringViews
+    // if there are many volumes. For simplicity, start with one BStringView
+    // and concatenate info, or use a BTextView.
+    BTextView*   fDiskInfoTextView; // For multi-line disk info
+    BScrollView* fDiskInfoScrollView;
+
+
+    // Main container for all sections
+    BBox* fMainSectionsBox;
+};
+
+#endif // SYSINFOVIEW_H

--- a/haiku_port/SysMonTaskApp.cpp
+++ b/haiku_port/SysMonTaskApp.cpp
@@ -1,0 +1,123 @@
+// Placeholder for the main Haiku application class
+// We will start implementing this based on Haiku's Application Kit
+
+#include <Application.h>
+#include <Window.h>
+#include <View.h>
+#include <Alert.h>
+#include <stdio.h>
+#include <LayoutBuilder.h> // For BLayoutBuilder
+#include <TabView.h>      // For BTabView
+
+#include "CPUView.h" // Include the new CPUView header
+#include "MemView.h" // Include the new MemView header
+#include "DiskView.h" // Include the new DiskView header
+#include "NetworkView.h" // Include the new NetworkView header
+#include "ProcessView.h" // Include the new ProcessView header
+#include "GPUView.h"     // Include the new GPUView header
+#include "SysInfoView.h" // Include the new SysInfoView header
+
+// Forward declaration
+class MainWindow;
+
+class SysMonTaskApp : public BApplication {
+public:
+    SysMonTaskApp();
+    virtual void ReadyToRun();
+
+private:
+    MainWindow* mainWindow;
+};
+
+class MainWindow : public BWindow {
+public:
+    MainWindow(BRect frame);
+    virtual bool QuitRequested();
+};
+
+MainWindow::MainWindow(BRect frame)
+    : BWindow(frame, "SysMonTask Haiku", B_TITLED_WINDOW, B_QUIT_ON_WINDOW_CLOSE) {
+
+    // Create a TabView
+    BTabView* tabView = new BTabView("tab_view", B_WIDTH_FROM_LABEL);
+
+    // Create CPU View
+    BRect tabFrame = tabView->Bounds();
+    // Adjust tabFrame for the actual tab content area (it's smaller than Bounds())
+    // This might require getting the container view of the tabview or adjusting after adding a tab.
+    // For now, let's assume Bounds() is close enough for initial placement.
+    // A better way is to let the TabView manage the frame of its children.
+
+    CPUView* cpuView = new CPUView(tabFrame); // Pass the tab's content area rect
+    BTab* cpuTab = new BTab(cpuView);
+    tabView->AddTab(cpuView, cpuTab);
+    cpuTab->SetLabel("CPU"); // Set label after adding if view is passed directly
+
+    // Create Memory View
+    MemView* memoryView = new MemView(tabFrame);
+    BTab* memTab = new BTab(memoryView);
+    tabView->AddTab(memoryView, memTab);
+    memTab->SetLabel("Memory");
+
+    // Create Disk View
+    DiskView* diskView = new DiskView(tabFrame);
+    BTab* diskTab = new BTab(diskView);
+    tabView->AddTab(diskView, diskTab);
+    diskTab->SetLabel("Disks");
+
+    // Create Network View
+    NetworkView* networkView = new NetworkView(tabFrame);
+    BTab* networkTab = new BTab(networkView);
+    tabView->AddTab(networkView, networkTab);
+    networkTab->SetLabel("Network");
+
+    // Create Process View
+    ProcessView* processView = new ProcessView(tabFrame);
+    BTab* processTab = new BTab(processView);
+    tabView->AddTab(processView, processTab);
+    processTab->SetLabel("Processes");
+
+    // Create GPU View
+    GPUView* gpuView = new GPUView(tabFrame);
+    BTab* gpuTab = new BTab(gpuView);
+    tabView->AddTab(gpuView, gpuTab);
+    gpuTab->SetLabel("GPU");
+
+    // Create System Info View
+    SysInfoView* sysInfoView = new SysInfoView(tabFrame);
+    BTab* sysInfoTab = new BTab(sysInfoView);
+    tabView->AddTab(sysInfoView, sysInfoTab);
+    sysInfoTab->SetLabel("System Info");
+
+    // Use BLayoutBuilder to add the tabView to the window
+    BLayoutBuilder::Group<>(this, B_VERTICAL, 0)
+        .SetInsets(0) // No insets for the main layout containing the tab view
+        .Add(tabView)
+    .End();
+
+    // Set PulseRate for the window, so views with B_PULSE_NEEDED will get Pulse() calls
+    // Pulse rate in microseconds. 1,000,000 microseconds = 1 second.
+    SetPulseRate(1000000); // Pulse once per second, adjust as needed
+}
+
+bool MainWindow::QuitRequested() {
+    be_app->PostMessage(B_QUIT_REQUESTED);
+    return true;
+}
+
+SysMonTaskApp::SysMonTaskApp()
+    : BApplication("application/x-vnd.SysMonTaskHaiku") {
+    // Constructor
+}
+
+void SysMonTaskApp::ReadyToRun() {
+    BRect windowRect(50, 50, 850, 650); // Adjust size as needed
+    mainWindow = new MainWindow(windowRect);
+    mainWindow->Show();
+}
+
+int main() {
+    SysMonTaskApp app;
+    app.Run();
+    return 0;
+}

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def get_data_files():
 
 setup(
     name='sysmontask',
-    version='1.x.x',
+    version='1.4.0',
     description='System Monitor With UI Like Windows',
     url='https://github.com/KrispyCamel4u/SysMonTask',
     author='Neeraj Kumar',


### PR DESCRIPTION
- Implemented a new SysInfoView tab to display detailed system information.
- Information includes:
  - OS: Kernel name, version, build date/time, CPU architecture, uptime.
  - CPU: Model, cores, clock speed, L1/L2/L3 cache sizes, features (SIMD).
  - Graphics: GPU type, driver, VRAM, screen resolution.
  - Memory: Total installed RAM.
  - Disks: List of volumes with name, mount point, FS type, total/free size.
- Uses Haiku native APIs (get_system_info, BScreen, BVolumeRoster, etc.).
- Information is presented in a scrollable view with organized sections.